### PR TITLE
Localize all lengths

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -77,6 +77,7 @@
         grid-area: main;
         justify-self: center;
         align-self: center;
+        z-index: 1;
       }
     }
   }

--- a/src/app/dialogs/cross-section-render-dialog/cross-section-render-dialog.component.ts
+++ b/src/app/dialogs/cross-section-render-dialog/cross-section-render-dialog.component.ts
@@ -93,7 +93,7 @@ export class CrossSectionRenderDialogComponent implements AfterViewInit {
       switchMap(renderer => {
         return this.formGroup.controls.dimensions.valueChanges.pipe(
           tap(dimensions => {
-            const newRatio = dimensions.width! / dimensions.height!;
+            const newRatio = dimensions.x! / dimensions.y!;
             const [newWidth, newHeight] = this.#calculateDimensions(newRatio);
             renderer.setSize(newWidth, newHeight);
           }),

--- a/src/app/dialogs/settings-dialog/settings-dialog.component.html
+++ b/src/app/dialogs/settings-dialog/settings-dialog.component.html
@@ -34,6 +34,6 @@
 
   <div mat-dialog-actions>
     <button mat-button mat-dialog-close>Close</button>
-    <button mat-button type="submit" [disabled]="!formGroup.dirty">Save settings</button>
+    <button mat-button type="submit" [disabled]="!formGroup.dirty">Save settings and reload</button>
   </div>
 </form>

--- a/src/app/dialogs/settings-dialog/settings-dialog.component.ts
+++ b/src/app/dialogs/settings-dialog/settings-dialog.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, DOCUMENT } from '@angular/common';
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -27,6 +27,7 @@ export class SettingsDialogComponent implements OnInit {
 
   readonly #destroyRef = inject(DestroyRef);
   readonly #settings = inject(SettingsService);
+  readonly #document = inject(DOCUMENT);
 
   readonly formGroup = new FormGroup({
     measurementSystem: new FormControl(undefined as MeasurementSystem | undefined, { validators: [Validators.required], nonNullable: true }),
@@ -46,5 +47,6 @@ export class SettingsDialogComponent implements OnInit {
 
   save() {
     this.#settings.updateSettings(this.formGroup.value);
+    this.#document.location.reload();
   }
 }

--- a/src/app/shared/components/cross-section-details-form/cross-section-details-form.component.html
+++ b/src/app/shared/components/cross-section-details-form/cross-section-details-form.component.html
@@ -24,15 +24,15 @@
     <div></div>
     <mat-form-field>
       <mat-label>Width</mat-label>
-      <input matInput type="number" [formControl]="formGroup.controls.dimensions.controls.width">
+      <input matInput type="number" [formControl]="formGroup.controls.dimensions.controls.x">
     </mat-form-field>
     <mat-form-field>
       <mat-label>Height</mat-label>
-      <input matInput type="number" [formControl]="formGroup.controls.dimensions.controls.height">
+      <input matInput type="number" [formControl]="formGroup.controls.dimensions.controls.y">
     </mat-form-field>
     <mat-form-field>
       <mat-label>Depth</mat-label>
-      <input matInput type="number" [formControl]="formGroup.controls.dimensions.controls.depth">
+      <input matInput type="number" [formControl]="formGroup.controls.dimensions.controls.z">
     </mat-form-field>
   </section>
   <mat-form-field>

--- a/src/app/shared/components/cross-section-details-form/cross-section-details-form.component.ts
+++ b/src/app/shared/components/cross-section-details-form/cross-section-details-form.component.ts
@@ -16,9 +16,9 @@ export type CrossSectionDetailsForm = FormGroup<{
     z: FormControl<number>,
   }>,
   dimensions: FormGroup<{
-    width: FormControl<number>,
-    height: FormControl<number>,
-    depth: FormControl<number>,
+    x: FormControl<number>,
+    y: FormControl<number>,
+    z: FormControl<number>,
   }>,
   rotationDegrees: FormControl<number>,
 }>;

--- a/src/app/shared/constants/zero-vectors.ts
+++ b/src/app/shared/constants/zero-vectors.ts
@@ -1,0 +1,7 @@
+import { ISimpleVector3 } from "../models/simple-types";
+
+export const zeroVector3 = Object.freeze({
+  x: 0,
+  y: 0,
+  z: 0,
+}) satisfies ISimpleVector3;

--- a/src/app/shared/models/annotations/cross-section.annotation.ts
+++ b/src/app/shared/models/annotations/cross-section.annotation.ts
@@ -5,6 +5,7 @@ import { IMetadataCrossSectionV0 } from "../manifest/types.v0";
 import { simpleVector3FromVector3 } from "../simple-types";
 import { IMapperUserData } from "../user-data";
 import { BaseAnnotation } from "./base.annotation";
+import { LocalizeService } from "../../services/localize.service";
 
 export const degreesPerRadian = 180 / Math.PI;
 
@@ -45,6 +46,8 @@ export class CrossSectionAnnotation extends BaseAnnotation {
   readonly #boxMesh: Mesh<BoxGeometry>;
   readonly #group: Group;
 
+  readonly #localize: LocalizeService;
+
   #camera?: OrthographicCamera;
   #measureLine?: Line<BufferGeometry>;
 
@@ -53,8 +56,11 @@ export class CrossSectionAnnotation extends BaseAnnotation {
     dimensions: Vector3,
     centerPoint: Vector3,
     radiansToNorthAroundY: number,
+    localize: LocalizeService,
   ) {
     super();
+
+    this.#localize = localize;
 
     this.#identifier = identifier;
     this.#radiansToNorthAroundY = radiansToNorthAroundY;
@@ -222,15 +228,18 @@ export class CrossSectionAnnotation extends BaseAnnotation {
   }
 
   *#getMeasureLinePoints() {
-    const xVector = new Vector3(1, 0, 0);
+    const unit = this.#localize.localLengthToMeters(1);
+    const xVector = new Vector3(unit, 0, 0);
 
     const width = this.dimensions.x;
 
+    const totalCount = this.#localize.metersToLocalLength(width + 2);
+
     const leftOrigin = new Vector3()
-      .sub(xVector.clone().multiplyScalar(width / 2 + 1));
+      .sub(xVector.clone().multiplyScalar(totalCount / 2 + 1));
 
     const currentPoint = leftOrigin.clone();
-    for (let i = 0; i < width + 2; ++i) {
+    for (let i = 0; i < totalCount; ++i) {
       yield currentPoint.clone();
 
       currentPoint.add(xVector);

--- a/src/app/shared/models/render/gltf.render-model.ts
+++ b/src/app/shared/models/render/gltf.render-model.ts
@@ -10,7 +10,8 @@ import { BaseAnnotation } from "../annotations/base.annotation";
 import { ModelChangeType } from "../model-change-type.enum";
 
 /**
- * TODO: basically unimplemented so far...
+ * TODO: #11: https://github.com/skgrush/cavern-seer-mapper/issues/11
+ * Basically unimplemented so far...
  */
 export class GltfRenderModel extends BaseVisibleRenderModel<FileModelType.gLTF> {
   override readonly type = FileModelType.gLTF;

--- a/src/app/shared/pipes/vector.pipe.ts
+++ b/src/app/shared/pipes/vector.pipe.ts
@@ -16,7 +16,9 @@ export class VectorPipe implements PipeTransform {
     const ary: number[] = [];
     value.toArray(ary);
 
-    const parts = ary.map(p => this.#localize.formatNumber(p, minimumFractionDigits, maximumFractionDigits));
+    const parts = ary
+      .map(p => this.#localize.metersToLocalLength(p))
+      .map(p => this.#localize.formatNumber(p, minimumFractionDigits, maximumFractionDigits));
 
     return this.#unitListFormat.format(parts);
   }

--- a/src/app/shared/services/annotation-builder.service.ts
+++ b/src/app/shared/services/annotation-builder.service.ts
@@ -82,6 +82,7 @@ export class AnnotationBuilderService {
       dimensions,
       centerPoint,
       angleToNorthAroundY / degreesPerRadian,
+      this.#localize,
     );
   }
 
@@ -119,6 +120,7 @@ export class AnnotationBuilderService {
       dimensions,
       centerPoint,
       radiansToNorthOfBoxNormal,
+      this.#localize,
     );
   }
 }

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -10,11 +10,13 @@ import { ignoreNullish } from '../operators/ignore-nullish';
 import { BaseMaterialService } from './3d-managers/base-material.service';
 import { MeshNormalMaterialService } from './3d-managers/mesh-normal-material.service';
 import { ModelManagerService } from './model-manager.service';
+import { LocalizeService } from './localize.service';
 
 @Injectable()
 export class CanvasService {
 
   readonly #modelManager = inject(ModelManagerService);
+  readonly #localize = inject(LocalizeService);
 
   readonly #renderClock = new Clock();
   readonly #scene = new Scene();
@@ -333,7 +335,7 @@ export class CanvasService {
     const size = Math.max(sizeX, sizeZ);
 
     this.#scene.remove(this.#bottomGrid);
-    const gridHelper = this.#bottomGrid = new GridHelper(size, size);
+    const gridHelper = this.#bottomGrid = new GridHelper(size, this.#localize.metersToLocalLength(size));
     gridHelper.position.x = boundsMin.x + sizeX / 2;
     gridHelper.position.y = boundsMin.y;
     gridHelper.position.z = boundsMin.z + sizeZ / 2;

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -340,6 +340,7 @@ export class CanvasService {
     let xDelta = sizeX / 2;
     let zDelta = sizeZ / 2;
 
+    // TODO: #9 https://github.com/skgrush/cavern-seer-mapper/issues/9
     // attempt to adjust the localized grid to be aligned with the localized coordinates
     if (!this.#localize.isMetric) {
       xDelta = this.#localize.localLengthToMeters(Math.round(this.#localize.metersToLocalLength(xDelta)));

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -336,9 +336,21 @@ export class CanvasService {
 
     this.#scene.remove(this.#bottomGrid);
     const gridHelper = this.#bottomGrid = new GridHelper(size, this.#localize.metersToLocalLength(size));
-    gridHelper.position.x = boundsMin.x + sizeX / 2;
-    gridHelper.position.y = boundsMin.y;
-    gridHelper.position.z = boundsMin.z + sizeZ / 2;
+
+    let xDelta = sizeX / 2;
+    let zDelta = sizeZ / 2;
+
+    // attempt to adjust the localized grid to be aligned with the localized coordinates
+    if (!this.#localize.isMetric) {
+      xDelta = this.#localize.localLengthToMeters(Math.round(this.#localize.metersToLocalLength(xDelta)));
+      zDelta = this.#localize.localLengthToMeters(Math.round(this.#localize.metersToLocalLength(zDelta)));
+    }
+
+    gridHelper.position.set(
+      boundsMin.x + xDelta,
+      boundsMin.y,
+      boundsMin.z + zDelta,
+    );
     this.#scene.add(gridHelper);
   }
 

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -401,7 +401,8 @@ export class CanvasService {
     this.#rendererMap.set(this.rendererSymbol, new WeakRef(this.#renderer));
     this.#renderer.autoClear = false;
     this.#renderer.setSize(width, height);
-    // TODO: setting pixel ratio screws with raycasting??
+    // #TODO: #10: https://github.com/skgrush/cavern-seer-mapper/issues/10
+    // // setting pixel ratio screws with raycasting??
     // this.#renderer.setPixelRatio(pixelRatio);
 
     this.#orthoCamera = this.#buildNewCamera(width, height);

--- a/src/app/shared/services/localize.service.ts
+++ b/src/app/shared/services/localize.service.ts
@@ -35,9 +35,13 @@ export class LocalizeService {
   readonly #unitLengthLookup = new Map<`${SupportedUnit}-${number}-${number}`, Intl.NumberFormat>();
   readonly #decimalLookup = new Map<`${number}-${number}`, Intl.NumberFormat>();
 
+  get isMetric() {
+    return this.#settings.measurementSystem === MeasurementSystem.metric;
+  }
+
   getLocalLengthUnits(): SupportedUnit {
     return (
-      this.#settings.measurementSystem === MeasurementSystem.metric
+      this.isMetric
         ? 'meter'
         : 'foot'
     );
@@ -51,14 +55,14 @@ export class LocalizeService {
   }
 
   metersToLocalLength(valueInMeters: number) {
-    if (this.#settings.measurementSystem === MeasurementSystem.metric) {
+    if (this.isMetric) {
       return valueInMeters;
     }
     return this.metersToFeet(valueInMeters);
   }
 
   localLengthToMeters(localLength: number) {
-    if (this.#settings.measurementSystem === MeasurementSystem.metric) {
+    if (this.isMetric) {
       return localLength;
     }
     return this.feetToMeters(localLength);


### PR DESCRIPTION
Goals:
- [x] All lengths, including in forms, are localized to the user's units
- [x] The grid is sized to local units
- [x] Cross section scale bar is in local length units

Directly related changes:
 - Saving settings reloads the page (button label updated to reflect this) as some things like the grid cannot be updated so easily
 - minimum dimension size is now 0.1 local units, to allow thinner cross-sections
 - new localization functions on `LocalizeService`:
    * `vectorMetersToLocalLength()` and `vectorLocalLengthToMeters()` for converting simple vectors
    * `metersToLocalLength()` and `localLengthToMeters()`
- VectorPipe is now localized, but still doesn't show units (for concision)

Additional changes:
 - Bugfix: only seen in Safari, but mapper-file-url-loader in app-root was not z-indexing correctly; changed so loading text is always visible.
 - Documentation: Associated existing TODOs with GH issues

Known bugs:
 - #9 