### PR TITLE
Make renderer lazier

### DIFF
--- a/src/app/shared/functions/traverse-some.ts
+++ b/src/app/shared/functions/traverse-some.ts
@@ -1,0 +1,12 @@
+import type { Object3D } from "three";
+
+/**
+ * Run the `fn` against this object and its children, recursively.
+ * Return `true` when the first call to `fn` returns `true`.
+ */
+export function traverseSome(obj: Object3D, fn: (o: Object3D) => boolean): boolean {
+  return (
+    fn(obj) ||
+    obj.children.some(child => traverseSome(child, fn))
+  );
+}

--- a/src/app/shared/models/annotations/cross-section.annotation.ts
+++ b/src/app/shared/models/annotations/cross-section.annotation.ts
@@ -116,6 +116,7 @@ export class CrossSectionAnnotation extends BaseAnnotation {
     cam.near = 0;
     cam.far = dims.z;
     cam.updateProjectionMatrix();
+    cam.matrixWorldNeedsUpdate = true;
   }
 
   #drawLine() {
@@ -150,6 +151,7 @@ export class CrossSectionAnnotation extends BaseAnnotation {
 
     this.#boxMesh.position.setZ(-newDimensions.z / 2);
     this.#boxMesh.geometry = new BoxGeometry(newDimensions.x, newDimensions.y, newDimensions.z);
+    this.#boxMesh.matrixWorldNeedsUpdate = true;
     this.#dimensions = newDimensions.clone();
     this.#updateCamera();
     this.#updateLine();
@@ -159,6 +161,7 @@ export class CrossSectionAnnotation extends BaseAnnotation {
     this.#radiansToNorthAroundY = angleDegrees / degreesPerRadian;
 
     this.#group.setRotationFromAxisAngle(new Vector3(0, 1, 0), -this.#radiansToNorthAroundY);
+    this.#group.matrixWorldNeedsUpdate = true;
 
     this.#updateCamera();
     this.#updateLine();
@@ -166,6 +169,7 @@ export class CrossSectionAnnotation extends BaseAnnotation {
 
   changeCenterPoint(pos: Vector3) {
     this.#group.position.copy(pos);
+    this.#group.matrixWorldNeedsUpdate = true;
   }
 
   override rename(newIdentifier: string): void {
@@ -221,6 +225,7 @@ export class CrossSectionAnnotation extends BaseAnnotation {
             this.#removeCamera();
             this.#group.remove(this.#measureLine!);
             this.#measureLine = undefined;
+            this.#group.matrixWorldNeedsUpdate = true;
           },
         })
       ),

--- a/src/app/shared/models/objects/control-view-helper.ts
+++ b/src/app/shared/models/objects/control-view-helper.ts
@@ -1,0 +1,373 @@
+import {
+  BoxGeometry,
+  Camera,
+  CanvasTexture,
+  Color,
+  Euler,
+  Mesh,
+  MeshBasicMaterial,
+  Object3D,
+  OrthographicCamera,
+  Quaternion,
+  Raycaster,
+  Sprite,
+  SpriteMaterial,
+  Vector2,
+  Vector3,
+  Vector4,
+  WebGLRenderer
+} from 'three';
+
+/**
+ * Copy of Three.JS's
+ * {@link https://github.com/mrdoob/three.js/blob/de6dd45d7e5aa58fed0fbc1dbe53def3402b39cc/examples/jsm/helpers/ViewHelper.js ViewHelper}
+ *
+ * but not reliant on auto updated matrices.
+ */
+export class ControlViewHelper extends Object3D {
+  readonly camera: Camera;
+  readonly domElement: HTMLElement;
+
+  get animating() {
+    return this.#animating;
+  }
+
+  readonly isViewHelper = true;
+  #animating = false;
+  readonly center = new Vector3();
+  readonly dim = 128;
+  readonly viewport = new Vector4();
+
+  readonly geometry = new BoxGeometry(0.8, 0.05, 0.05).translate(0.4, 0, 0);
+
+  readonly interactiveObjects: Sprite[] = [];
+  readonly raycaster = new Raycaster();
+  readonly mouse = new Vector2();
+  readonly dummy = new Object3D();
+
+  readonly posXAxisHelper: Sprite;
+  readonly posYAxisHelper: Sprite;
+  readonly posZAxisHelper: Sprite;
+  readonly negXAxisHelper: Sprite;
+  readonly negYAxisHelper: Sprite;
+  readonly negZAxisHelper: Sprite;
+
+  readonly xAxis: Mesh<BoxGeometry, MeshBasicMaterial>;
+  readonly yAxis: Mesh<BoxGeometry, MeshBasicMaterial>;
+  readonly zAxis: Mesh<BoxGeometry, MeshBasicMaterial>;
+
+  readonly point = new Vector3();
+
+  readonly orthoCamera = new OrthographicCamera(- 2, 2, 2, - 2, 0, 4);
+
+  readonly turnRate = 2 * Math.PI; // turn rate in angles per second
+
+  readonly targetPosition = new Vector3();
+  readonly targetQuaternion = new Quaternion();
+
+  readonly q1 = new Quaternion();
+  readonly q2 = new Quaternion();
+  #radius = 0;
+
+  constructor(camera: Camera, domElement: HTMLElement) {
+
+    super();
+
+    this.camera = camera;
+    this.domElement = domElement;
+
+    const color1 = new Color('#ff3653');
+    const color2 = new Color('#8adb00');
+    const color3 = new Color('#2c8fff');
+
+    this.orthoCamera.position.set(0, 0, 2);
+    this.orthoCamera.updateMatrix(); // Not in original implementation
+    this.orthoCamera.updateMatrixWorld(true); // Not in original implementation
+
+    this.xAxis = new Mesh(this.geometry, this.getAxisMaterial(color1));
+    this.yAxis = new Mesh(this.geometry, this.getAxisMaterial(color2));
+    this.zAxis = new Mesh(this.geometry, this.getAxisMaterial(color3));
+
+    this.yAxis.rotation.z = Math.PI / 2;
+    this.zAxis.rotation.y = - Math.PI / 2;
+
+    this.add(this.xAxis);
+    this.add(this.zAxis);
+    this.add(this.yAxis);
+
+    this.posXAxisHelper = new Sprite(this.getSpriteMaterial(color1, 'X'));
+    this.posXAxisHelper.userData['type'] = 'posX';
+    this.posYAxisHelper = new Sprite(this.getSpriteMaterial(color2, 'Y'));
+    this.posYAxisHelper.userData['type'] = 'posY';
+    this.posZAxisHelper = new Sprite(this.getSpriteMaterial(color3, 'Z'));
+    this.posZAxisHelper.userData['type'] = 'posZ';
+    this.negXAxisHelper = new Sprite(this.getSpriteMaterial(color1));
+    this.negXAxisHelper.userData['type'] = 'negX';
+    this.negYAxisHelper = new Sprite(this.getSpriteMaterial(color2));
+    this.negYAxisHelper.userData['type'] = 'negY';
+    this.negZAxisHelper = new Sprite(this.getSpriteMaterial(color3));
+    this.negZAxisHelper.userData['type'] = 'negZ';
+
+    this.posXAxisHelper.position.x = 1;
+    this.posYAxisHelper.position.y = 1;
+    this.posZAxisHelper.position.z = 1;
+    this.negXAxisHelper.position.x = - 1;
+    this.negXAxisHelper.scale.setScalar(0.8);
+    this.negYAxisHelper.position.y = - 1;
+    this.negYAxisHelper.scale.setScalar(0.8);
+    this.negZAxisHelper.position.z = - 1;
+    this.negZAxisHelper.scale.setScalar(0.8);
+
+    this.add(this.posXAxisHelper);
+    this.add(this.posYAxisHelper);
+    this.add(this.posZAxisHelper);
+    this.add(this.negXAxisHelper);
+    this.add(this.negYAxisHelper);
+    this.add(this.negZAxisHelper);
+
+    this.interactiveObjects.push(this.posXAxisHelper);
+    this.interactiveObjects.push(this.posYAxisHelper);
+    this.interactiveObjects.push(this.posZAxisHelper);
+    this.interactiveObjects.push(this.negXAxisHelper);
+    this.interactiveObjects.push(this.negYAxisHelper);
+    this.interactiveObjects.push(this.negZAxisHelper);
+
+    this.traverse(c => c.updateMatrix());
+  }
+
+  render(renderer: WebGLRenderer) {
+
+    const point = this.point;
+    const dim = this.dim;
+    const viewport = this.viewport;
+
+    this.quaternion.copy(this.camera.quaternion).invert();
+    this.updateMatrix();
+    this.updateMatrixWorld(true);
+
+    point.set(0, 0, 1);
+    point.applyQuaternion(this.camera.quaternion);
+
+    if (point.x >= 0) {
+
+      this.posXAxisHelper.material.opacity = 1;
+      this.negXAxisHelper.material.opacity = 0.5;
+
+    } else {
+
+      this.posXAxisHelper.material.opacity = 0.5;
+      this.negXAxisHelper.material.opacity = 1;
+
+    }
+
+    if (point.y >= 0) {
+
+      this.posYAxisHelper.material.opacity = 1;
+      this.negYAxisHelper.material.opacity = 0.5;
+
+    } else {
+
+      this.posYAxisHelper.material.opacity = 0.5;
+      this.negYAxisHelper.material.opacity = 1;
+
+    }
+
+    if (point.z >= 0) {
+
+      this.posZAxisHelper.material.opacity = 1;
+      this.negZAxisHelper.material.opacity = 0.5;
+
+    } else {
+
+      this.posZAxisHelper.material.opacity = 0.5;
+      this.negZAxisHelper.material.opacity = 1;
+
+    }
+
+    //
+
+    const x = this.domElement.offsetWidth - dim;
+
+    renderer.clearDepth();
+
+    renderer.getViewport(viewport);
+    renderer.setViewport(x, 0, dim, dim);
+
+    renderer.render(this, this.orthoCamera);
+
+    renderer.setViewport(viewport.x, viewport.y, viewport.z, viewport.w);
+
+  };
+
+  handleClick(event: MouseEvent) {
+
+    if (this.#animating === true) return false;
+
+    const domElement = this.domElement;
+    const mouse = this.mouse;
+
+    const rect = domElement.getBoundingClientRect();
+    const offsetX = rect.left + (domElement.offsetWidth - this.dim);
+    const offsetY = rect.top + (domElement.offsetHeight - this.dim);
+    mouse.x = ((event.clientX - offsetX) / (rect.right - offsetX)) * 2 - 1;
+    mouse.y = - ((event.clientY - offsetY) / (rect.bottom - offsetY)) * 2 + 1;
+
+    this.raycaster.setFromCamera(mouse, this.orthoCamera);
+
+    const intersects = this.raycaster.intersectObjects(this.interactiveObjects);
+
+    if (intersects.length > 0) {
+
+      const intersection = intersects[0];
+      const object = intersection.object;
+
+      this.prepareAnimationData(object, this.center);
+
+      this.#animating = true;
+
+      return true;
+
+    } else {
+      return false;
+    }
+
+  };
+
+  update(delta: number) {
+
+    const q1 = this.q1;
+    const q2 = this.q2;
+
+    const step = delta * this.turnRate;
+
+    // animate position by doing a slerp and then scaling the position on the unit sphere
+
+    q1.rotateTowards(q2, step);
+    this.camera.position.set(0, 0, 1).applyQuaternion(q1).multiplyScalar(this.#radius).add(this.center);
+    this.camera.updateMatrixWorld(true);
+
+    // animate orientation
+
+    this.camera.quaternion.rotateTowards(this.targetQuaternion, step);
+
+    if (q1.angleTo(q2) === 0) {
+
+      this.#animating = false;
+
+    }
+
+  };
+
+  dispose() {
+
+    this.geometry.dispose();
+
+    this.xAxis.material.dispose();
+    this.yAxis.material.dispose();
+    this.zAxis.material.dispose();
+
+    this.posXAxisHelper.material.map?.dispose();
+    this.posYAxisHelper.material.map?.dispose();
+    this.posZAxisHelper.material.map?.dispose();
+    this.negXAxisHelper.material.map?.dispose();
+    this.negYAxisHelper.material.map?.dispose();
+    this.negZAxisHelper.material.map?.dispose();
+
+    this.posXAxisHelper.material.dispose();
+    this.posYAxisHelper.material.dispose();
+    this.posZAxisHelper.material.dispose();
+    this.negXAxisHelper.material.dispose();
+    this.negYAxisHelper.material.dispose();
+    this.negZAxisHelper.material.dispose();
+
+  };
+
+  prepareAnimationData(object: Object3D, focusPoint: Vector3) {
+
+    switch (object.userData['type']) {
+
+      case 'posX':
+        this.targetPosition.set(1, 0, 0);
+        this.targetQuaternion.setFromEuler(new Euler(0, Math.PI * 0.5, 0));
+        break;
+
+      case 'posY':
+        this.targetPosition.set(0, 1, 0);
+        this.targetQuaternion.setFromEuler(new Euler(- Math.PI * 0.5, 0, 0));
+        break;
+
+      case 'posZ':
+        this.targetPosition.set(0, 0, 1);
+        this.targetQuaternion.setFromEuler(new Euler());
+        break;
+
+      case 'negX':
+        this.targetPosition.set(- 1, 0, 0);
+        this.targetQuaternion.setFromEuler(new Euler(0, - Math.PI * 0.5, 0));
+        break;
+
+      case 'negY':
+        this.targetPosition.set(0, - 1, 0);
+        this.targetQuaternion.setFromEuler(new Euler(Math.PI * 0.5, 0, 0));
+        break;
+
+      case 'negZ':
+        this.targetPosition.set(0, 0, - 1);
+        this.targetQuaternion.setFromEuler(new Euler(0, Math.PI, 0));
+        break;
+
+      default:
+        console.error('ViewHelper: Invalid axis.');
+
+    }
+
+    //
+
+    this.#radius = this.camera.position.distanceTo(focusPoint);
+    this.targetPosition.multiplyScalar(this.#radius).add(focusPoint);
+
+    this.dummy.position.copy(focusPoint);
+
+    this.dummy.lookAt(this.camera.position);
+    this.q1.copy(this.dummy.quaternion);
+
+    this.dummy.lookAt(this.targetPosition);
+    this.q2.copy(this.dummy.quaternion);
+
+  }
+
+  getAxisMaterial(color: Color) {
+
+    return new MeshBasicMaterial({ color: color, toneMapped: false });
+
+  }
+
+  getSpriteMaterial(color: Color, text: 'X' | 'Y' | 'Z' | null = null) {
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+
+    const context = canvas.getContext('2d')!;
+    context.beginPath();
+    context.arc(32, 32, 16, 0, 2 * Math.PI);
+    context.closePath();
+    context.fillStyle = color.getStyle();
+    context.fill();
+
+    if (text !== null) {
+
+      context.font = '24px Arial';
+      context.textAlign = 'center';
+      context.fillStyle = '#000000';
+      context.fillText(text, 32, 41);
+
+    }
+
+    const texture = new CanvasTexture(canvas);
+
+    return new SpriteMaterial({ map: texture, toneMapped: false });
+
+  }
+
+}

--- a/src/app/shared/models/objects/control-view-helper.ts
+++ b/src/app/shared/models/objects/control-view-helper.ts
@@ -25,175 +25,174 @@ import {
  * but not reliant on auto updated matrices.
  */
 export class ControlViewHelper extends Object3D {
-  readonly camera: Camera;
-  readonly domElement: HTMLElement;
+  readonly #camera: Camera;
+  readonly #domElement: HTMLElement;
 
+  readonly isViewHelper = true;
+  readonly center = new Vector3();
+  #animating = false;
   get animating() {
     return this.#animating;
   }
 
-  readonly isViewHelper = true;
-  #animating = false;
-  readonly center = new Vector3();
-  readonly dim = 128;
-  readonly viewport = new Vector4();
+  readonly #dim = 128;
+  readonly #viewport = new Vector4();
 
-  readonly geometry = new BoxGeometry(0.8, 0.05, 0.05).translate(0.4, 0, 0);
+  readonly #geometry = new BoxGeometry(0.8, 0.05, 0.05).translate(0.4, 0, 0);
 
-  readonly interactiveObjects: Sprite[] = [];
-  readonly raycaster = new Raycaster();
-  readonly mouse = new Vector2();
-  readonly dummy = new Object3D();
+  readonly #interactiveObjects: Sprite[] = [];
+  readonly #raycaster = new Raycaster();
+  readonly #mouse = new Vector2();
+  readonly #dummy = new Object3D();
 
-  readonly posXAxisHelper: Sprite;
-  readonly posYAxisHelper: Sprite;
-  readonly posZAxisHelper: Sprite;
-  readonly negXAxisHelper: Sprite;
-  readonly negYAxisHelper: Sprite;
-  readonly negZAxisHelper: Sprite;
+  readonly #posXAxisHelper: Sprite;
+  readonly #posYAxisHelper: Sprite;
+  readonly #posZAxisHelper: Sprite;
+  readonly #negXAxisHelper: Sprite;
+  readonly #negYAxisHelper: Sprite;
+  readonly #negZAxisHelper: Sprite;
 
-  readonly xAxis: Mesh<BoxGeometry, MeshBasicMaterial>;
-  readonly yAxis: Mesh<BoxGeometry, MeshBasicMaterial>;
-  readonly zAxis: Mesh<BoxGeometry, MeshBasicMaterial>;
+  readonly #xAxis: Mesh<BoxGeometry, MeshBasicMaterial>;
+  readonly #yAxis: Mesh<BoxGeometry, MeshBasicMaterial>;
+  readonly #zAxis: Mesh<BoxGeometry, MeshBasicMaterial>;
 
-  readonly point = new Vector3();
+  readonly #point = new Vector3();
 
-  readonly orthoCamera = new OrthographicCamera(- 2, 2, 2, - 2, 0, 4);
+  readonly #orthoCamera = new OrthographicCamera(- 2, 2, 2, - 2, 0, 4);
 
-  readonly turnRate = 2 * Math.PI; // turn rate in angles per second
+  readonly #turnRate = 2 * Math.PI; // turn rate in angles per second
 
-  readonly targetPosition = new Vector3();
-  readonly targetQuaternion = new Quaternion();
+  readonly #targetPosition = new Vector3();
+  readonly #targetQuaternion = new Quaternion();
 
-  readonly q1 = new Quaternion();
-  readonly q2 = new Quaternion();
+  readonly #q1 = new Quaternion();
+  readonly #q2 = new Quaternion();
   #radius = 0;
 
   constructor(camera: Camera, domElement: HTMLElement) {
-
     super();
 
-    this.camera = camera;
-    this.domElement = domElement;
+    this.#camera = camera;
+    this.#domElement = domElement;
 
     const color1 = new Color('#ff3653');
     const color2 = new Color('#8adb00');
     const color3 = new Color('#2c8fff');
 
-    this.orthoCamera.position.set(0, 0, 2);
-    this.orthoCamera.updateMatrix(); // Not in original implementation
-    this.orthoCamera.updateMatrixWorld(true); // Not in original implementation
+    this.#orthoCamera.position.set(0, 0, 2);
+    this.#orthoCamera.updateMatrix(); // Not in original implementation
+    this.#orthoCamera.updateMatrixWorld(true); // Not in original implementation
 
-    this.xAxis = new Mesh(this.geometry, this.getAxisMaterial(color1));
-    this.yAxis = new Mesh(this.geometry, this.getAxisMaterial(color2));
-    this.zAxis = new Mesh(this.geometry, this.getAxisMaterial(color3));
+    this.#xAxis = new Mesh(this.#geometry, this.#getAxisMaterial(color1));
+    this.#yAxis = new Mesh(this.#geometry, this.#getAxisMaterial(color2));
+    this.#zAxis = new Mesh(this.#geometry, this.#getAxisMaterial(color3));
 
-    this.yAxis.rotation.z = Math.PI / 2;
-    this.zAxis.rotation.y = - Math.PI / 2;
+    this.#yAxis.rotation.z = Math.PI / 2;
+    this.#zAxis.rotation.y = - Math.PI / 2;
 
-    this.add(this.xAxis);
-    this.add(this.zAxis);
-    this.add(this.yAxis);
+    this.add(this.#xAxis);
+    this.add(this.#zAxis);
+    this.add(this.#yAxis);
 
-    this.posXAxisHelper = new Sprite(this.getSpriteMaterial(color1, 'X'));
-    this.posXAxisHelper.userData['type'] = 'posX';
-    this.posYAxisHelper = new Sprite(this.getSpriteMaterial(color2, 'Y'));
-    this.posYAxisHelper.userData['type'] = 'posY';
-    this.posZAxisHelper = new Sprite(this.getSpriteMaterial(color3, 'Z'));
-    this.posZAxisHelper.userData['type'] = 'posZ';
-    this.negXAxisHelper = new Sprite(this.getSpriteMaterial(color1));
-    this.negXAxisHelper.userData['type'] = 'negX';
-    this.negYAxisHelper = new Sprite(this.getSpriteMaterial(color2));
-    this.negYAxisHelper.userData['type'] = 'negY';
-    this.negZAxisHelper = new Sprite(this.getSpriteMaterial(color3));
-    this.negZAxisHelper.userData['type'] = 'negZ';
+    this.#posXAxisHelper = new Sprite(this.#getSpriteMaterial(color1, 'X'));
+    this.#posXAxisHelper.userData['type'] = 'posX';
+    this.#posYAxisHelper = new Sprite(this.#getSpriteMaterial(color2, 'Y'));
+    this.#posYAxisHelper.userData['type'] = 'posY';
+    this.#posZAxisHelper = new Sprite(this.#getSpriteMaterial(color3, 'Z'));
+    this.#posZAxisHelper.userData['type'] = 'posZ';
+    this.#negXAxisHelper = new Sprite(this.#getSpriteMaterial(color1));
+    this.#negXAxisHelper.userData['type'] = 'negX';
+    this.#negYAxisHelper = new Sprite(this.#getSpriteMaterial(color2));
+    this.#negYAxisHelper.userData['type'] = 'negY';
+    this.#negZAxisHelper = new Sprite(this.#getSpriteMaterial(color3));
+    this.#negZAxisHelper.userData['type'] = 'negZ';
 
-    this.posXAxisHelper.position.x = 1;
-    this.posYAxisHelper.position.y = 1;
-    this.posZAxisHelper.position.z = 1;
-    this.negXAxisHelper.position.x = - 1;
-    this.negXAxisHelper.scale.setScalar(0.8);
-    this.negYAxisHelper.position.y = - 1;
-    this.negYAxisHelper.scale.setScalar(0.8);
-    this.negZAxisHelper.position.z = - 1;
-    this.negZAxisHelper.scale.setScalar(0.8);
+    this.#posXAxisHelper.position.x = 1;
+    this.#posYAxisHelper.position.y = 1;
+    this.#posZAxisHelper.position.z = 1;
+    this.#negXAxisHelper.position.x = - 1;
+    this.#negXAxisHelper.scale.setScalar(0.8);
+    this.#negYAxisHelper.position.y = - 1;
+    this.#negYAxisHelper.scale.setScalar(0.8);
+    this.#negZAxisHelper.position.z = - 1;
+    this.#negZAxisHelper.scale.setScalar(0.8);
 
-    this.add(this.posXAxisHelper);
-    this.add(this.posYAxisHelper);
-    this.add(this.posZAxisHelper);
-    this.add(this.negXAxisHelper);
-    this.add(this.negYAxisHelper);
-    this.add(this.negZAxisHelper);
+    this.add(this.#posXAxisHelper);
+    this.add(this.#posYAxisHelper);
+    this.add(this.#posZAxisHelper);
+    this.add(this.#negXAxisHelper);
+    this.add(this.#negYAxisHelper);
+    this.add(this.#negZAxisHelper);
 
-    this.interactiveObjects.push(this.posXAxisHelper);
-    this.interactiveObjects.push(this.posYAxisHelper);
-    this.interactiveObjects.push(this.posZAxisHelper);
-    this.interactiveObjects.push(this.negXAxisHelper);
-    this.interactiveObjects.push(this.negYAxisHelper);
-    this.interactiveObjects.push(this.negZAxisHelper);
+    this.#interactiveObjects.push(this.#posXAxisHelper);
+    this.#interactiveObjects.push(this.#posYAxisHelper);
+    this.#interactiveObjects.push(this.#posZAxisHelper);
+    this.#interactiveObjects.push(this.#negXAxisHelper);
+    this.#interactiveObjects.push(this.#negYAxisHelper);
+    this.#interactiveObjects.push(this.#negZAxisHelper);
 
     this.traverse(c => c.updateMatrix());
   }
 
   render(renderer: WebGLRenderer) {
 
-    const point = this.point;
-    const dim = this.dim;
-    const viewport = this.viewport;
+    const point = this.#point;
+    const dim = this.#dim;
+    const viewport = this.#viewport;
 
-    this.quaternion.copy(this.camera.quaternion).invert();
+    this.quaternion.copy(this.#camera.quaternion).invert();
     this.updateMatrix();
     this.updateMatrixWorld(true);
 
     point.set(0, 0, 1);
-    point.applyQuaternion(this.camera.quaternion);
+    point.applyQuaternion(this.#camera.quaternion);
 
     if (point.x >= 0) {
 
-      this.posXAxisHelper.material.opacity = 1;
-      this.negXAxisHelper.material.opacity = 0.5;
+      this.#posXAxisHelper.material.opacity = 1;
+      this.#negXAxisHelper.material.opacity = 0.5;
 
     } else {
 
-      this.posXAxisHelper.material.opacity = 0.5;
-      this.negXAxisHelper.material.opacity = 1;
+      this.#posXAxisHelper.material.opacity = 0.5;
+      this.#negXAxisHelper.material.opacity = 1;
 
     }
 
     if (point.y >= 0) {
 
-      this.posYAxisHelper.material.opacity = 1;
-      this.negYAxisHelper.material.opacity = 0.5;
+      this.#posYAxisHelper.material.opacity = 1;
+      this.#negYAxisHelper.material.opacity = 0.5;
 
     } else {
 
-      this.posYAxisHelper.material.opacity = 0.5;
-      this.negYAxisHelper.material.opacity = 1;
+      this.#posYAxisHelper.material.opacity = 0.5;
+      this.#negYAxisHelper.material.opacity = 1;
 
     }
 
     if (point.z >= 0) {
 
-      this.posZAxisHelper.material.opacity = 1;
-      this.negZAxisHelper.material.opacity = 0.5;
+      this.#posZAxisHelper.material.opacity = 1;
+      this.#negZAxisHelper.material.opacity = 0.5;
 
     } else {
 
-      this.posZAxisHelper.material.opacity = 0.5;
-      this.negZAxisHelper.material.opacity = 1;
+      this.#posZAxisHelper.material.opacity = 0.5;
+      this.#negZAxisHelper.material.opacity = 1;
 
     }
 
     //
 
-    const x = this.domElement.offsetWidth - dim;
+    const x = this.#domElement.offsetWidth - dim;
 
     renderer.clearDepth();
 
     renderer.getViewport(viewport);
     renderer.setViewport(x, 0, dim, dim);
 
-    renderer.render(this, this.orthoCamera);
+    renderer.render(this, this.#orthoCamera);
 
     renderer.setViewport(viewport.x, viewport.y, viewport.z, viewport.w);
 
@@ -203,25 +202,25 @@ export class ControlViewHelper extends Object3D {
 
     if (this.#animating === true) return false;
 
-    const domElement = this.domElement;
-    const mouse = this.mouse;
+    const domElement = this.#domElement;
+    const mouse = this.#mouse;
 
     const rect = domElement.getBoundingClientRect();
-    const offsetX = rect.left + (domElement.offsetWidth - this.dim);
-    const offsetY = rect.top + (domElement.offsetHeight - this.dim);
+    const offsetX = rect.left + (domElement.offsetWidth - this.#dim);
+    const offsetY = rect.top + (domElement.offsetHeight - this.#dim);
     mouse.x = ((event.clientX - offsetX) / (rect.right - offsetX)) * 2 - 1;
     mouse.y = - ((event.clientY - offsetY) / (rect.bottom - offsetY)) * 2 + 1;
 
-    this.raycaster.setFromCamera(mouse, this.orthoCamera);
+    this.#raycaster.setFromCamera(mouse, this.#orthoCamera);
 
-    const intersects = this.raycaster.intersectObjects(this.interactiveObjects);
+    const intersects = this.#raycaster.intersectObjects(this.#interactiveObjects);
 
     if (intersects.length > 0) {
 
       const intersection = intersects[0];
       const object = intersection.object;
 
-      this.prepareAnimationData(object, this.center);
+      this.#prepareAnimationData(object, this.center);
 
       this.#animating = true;
 
@@ -235,20 +234,20 @@ export class ControlViewHelper extends Object3D {
 
   update(delta: number) {
 
-    const q1 = this.q1;
-    const q2 = this.q2;
+    const q1 = this.#q1;
+    const q2 = this.#q2;
 
-    const step = delta * this.turnRate;
+    const step = delta * this.#turnRate;
 
     // animate position by doing a slerp and then scaling the position on the unit sphere
 
     q1.rotateTowards(q2, step);
-    this.camera.position.set(0, 0, 1).applyQuaternion(q1).multiplyScalar(this.#radius).add(this.center);
-    this.camera.updateMatrixWorld(true);
+    this.#camera.position.set(0, 0, 1).applyQuaternion(q1).multiplyScalar(this.#radius).add(this.center);
+    this.#camera.updateMatrixWorld(true);
 
     // animate orientation
 
-    this.camera.quaternion.rotateTowards(this.targetQuaternion, step);
+    this.#camera.quaternion.rotateTowards(this.#targetQuaternion, step);
 
     if (q1.angleTo(q2) === 0) {
 
@@ -260,60 +259,60 @@ export class ControlViewHelper extends Object3D {
 
   dispose() {
 
-    this.geometry.dispose();
+    this.#geometry.dispose();
 
-    this.xAxis.material.dispose();
-    this.yAxis.material.dispose();
-    this.zAxis.material.dispose();
+    this.#xAxis.material.dispose();
+    this.#yAxis.material.dispose();
+    this.#zAxis.material.dispose();
 
-    this.posXAxisHelper.material.map?.dispose();
-    this.posYAxisHelper.material.map?.dispose();
-    this.posZAxisHelper.material.map?.dispose();
-    this.negXAxisHelper.material.map?.dispose();
-    this.negYAxisHelper.material.map?.dispose();
-    this.negZAxisHelper.material.map?.dispose();
+    this.#posXAxisHelper.material.map?.dispose();
+    this.#posYAxisHelper.material.map?.dispose();
+    this.#posZAxisHelper.material.map?.dispose();
+    this.#negXAxisHelper.material.map?.dispose();
+    this.#negYAxisHelper.material.map?.dispose();
+    this.#negZAxisHelper.material.map?.dispose();
 
-    this.posXAxisHelper.material.dispose();
-    this.posYAxisHelper.material.dispose();
-    this.posZAxisHelper.material.dispose();
-    this.negXAxisHelper.material.dispose();
-    this.negYAxisHelper.material.dispose();
-    this.negZAxisHelper.material.dispose();
+    this.#posXAxisHelper.material.dispose();
+    this.#posYAxisHelper.material.dispose();
+    this.#posZAxisHelper.material.dispose();
+    this.#negXAxisHelper.material.dispose();
+    this.#negYAxisHelper.material.dispose();
+    this.#negZAxisHelper.material.dispose();
 
   };
 
-  prepareAnimationData(object: Object3D, focusPoint: Vector3) {
+  #prepareAnimationData(object: Object3D, focusPoint: Vector3) {
 
     switch (object.userData['type']) {
 
       case 'posX':
-        this.targetPosition.set(1, 0, 0);
-        this.targetQuaternion.setFromEuler(new Euler(0, Math.PI * 0.5, 0));
+        this.#targetPosition.set(1, 0, 0);
+        this.#targetQuaternion.setFromEuler(new Euler(0, Math.PI * 0.5, 0));
         break;
 
       case 'posY':
-        this.targetPosition.set(0, 1, 0);
-        this.targetQuaternion.setFromEuler(new Euler(- Math.PI * 0.5, 0, 0));
+        this.#targetPosition.set(0, 1, 0);
+        this.#targetQuaternion.setFromEuler(new Euler(- Math.PI * 0.5, 0, 0));
         break;
 
       case 'posZ':
-        this.targetPosition.set(0, 0, 1);
-        this.targetQuaternion.setFromEuler(new Euler());
+        this.#targetPosition.set(0, 0, 1);
+        this.#targetQuaternion.setFromEuler(new Euler());
         break;
 
       case 'negX':
-        this.targetPosition.set(- 1, 0, 0);
-        this.targetQuaternion.setFromEuler(new Euler(0, - Math.PI * 0.5, 0));
+        this.#targetPosition.set(- 1, 0, 0);
+        this.#targetQuaternion.setFromEuler(new Euler(0, - Math.PI * 0.5, 0));
         break;
 
       case 'negY':
-        this.targetPosition.set(0, - 1, 0);
-        this.targetQuaternion.setFromEuler(new Euler(Math.PI * 0.5, 0, 0));
+        this.#targetPosition.set(0, - 1, 0);
+        this.#targetQuaternion.setFromEuler(new Euler(Math.PI * 0.5, 0, 0));
         break;
 
       case 'negZ':
-        this.targetPosition.set(0, 0, - 1);
-        this.targetQuaternion.setFromEuler(new Euler(0, Math.PI, 0));
+        this.#targetPosition.set(0, 0, - 1);
+        this.#targetQuaternion.setFromEuler(new Euler(0, Math.PI, 0));
         break;
 
       default:
@@ -323,26 +322,26 @@ export class ControlViewHelper extends Object3D {
 
     //
 
-    this.#radius = this.camera.position.distanceTo(focusPoint);
-    this.targetPosition.multiplyScalar(this.#radius).add(focusPoint);
+    this.#radius = this.#camera.position.distanceTo(focusPoint);
+    this.#targetPosition.multiplyScalar(this.#radius).add(focusPoint);
 
-    this.dummy.position.copy(focusPoint);
+    this.#dummy.position.copy(focusPoint);
 
-    this.dummy.lookAt(this.camera.position);
-    this.q1.copy(this.dummy.quaternion);
+    this.#dummy.lookAt(this.#camera.position);
+    this.#q1.copy(this.#dummy.quaternion);
 
-    this.dummy.lookAt(this.targetPosition);
-    this.q2.copy(this.dummy.quaternion);
+    this.#dummy.lookAt(this.#targetPosition);
+    this.#q2.copy(this.#dummy.quaternion);
 
   }
 
-  getAxisMaterial(color: Color) {
+  #getAxisMaterial(color: Color) {
 
     return new MeshBasicMaterial({ color: color, toneMapped: false });
 
   }
 
-  getSpriteMaterial(color: Color, text: 'X' | 'Y' | 'Z' | null = null) {
+  #getSpriteMaterial(color: Color, text: 'X' | 'Y' | 'Z' | null = null) {
 
     const canvas = document.createElement('canvas');
     canvas.width = 64;

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -5,6 +5,7 @@ import { AmbientLight, Box3, Camera, Clock, FrontSide, GridHelper, Material, Ort
 import { MapControls } from 'three/examples/jsm/controls/MapControls.js';
 import { ViewHelper } from 'three/examples/jsm/helpers/ViewHelper.js';
 import { ModelChangeType } from '../models/model-change-type.enum';
+import { ControlViewHelper } from '../models/objects/control-view-helper';
 import { GroupRenderModel } from '../models/render/group.render-model';
 import { ignoreNullish } from '../operators/ignore-nullish';
 import { BaseMaterialService } from './3d-managers/base-material.service';
@@ -37,7 +38,7 @@ export class CanvasService {
   #orthoControls?: MapControls;
 
   readonly #compassDivSubject = new BehaviorSubject<HTMLElement | undefined>(undefined);
-  #compass?: ViewHelper;
+  #compass?: ControlViewHelper;
 
   readonly #meshNormalMaterial = inject(MeshNormalMaterialService);
   #material: BaseMaterialService<Material> = this.#meshNormalMaterial;
@@ -419,7 +420,7 @@ export class CanvasService {
         if (!ele || !this.#orthoControls || !this.#renderer?.domElement) {
           return undefined;
         }
-        const compass = new ViewHelper(this.#orthoControls.object, this.#renderer.domElement);
+        const compass = new ControlViewHelper(this.#orthoControls.object, this.#renderer.domElement);
         ele.addEventListener('pointerup', e => compass.handleClick(e));
         this.#compass = compass;
         return compass;

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -3,15 +3,15 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, Observable, Subject, animationFrames, defer, distinctUntilChanged, filter, fromEvent, map, scan, switchMap, takeUntil, tap } from 'rxjs';
 import { AmbientLight, Box3, Camera, Clock, FrontSide, GridHelper, Material, OrthographicCamera, Raycaster, Scene, Side, Vector2, Vector3, WebGLRenderer } from 'three';
 import { MapControls } from 'three/examples/jsm/controls/MapControls.js';
-import { ViewHelper } from 'three/examples/jsm/helpers/ViewHelper.js';
+import { traverseSome } from '../functions/traverse-some';
 import { ModelChangeType } from '../models/model-change-type.enum';
 import { ControlViewHelper } from '../models/objects/control-view-helper';
 import { GroupRenderModel } from '../models/render/group.render-model';
 import { ignoreNullish } from '../operators/ignore-nullish';
 import { BaseMaterialService } from './3d-managers/base-material.service';
 import { MeshNormalMaterialService } from './3d-managers/mesh-normal-material.service';
-import { ModelManagerService } from './model-manager.service';
 import { LocalizeService } from './localize.service';
+import { ModelManagerService } from './model-manager.service';
 
 @Injectable()
 export class CanvasService {
@@ -124,6 +124,7 @@ export class CanvasService {
     this.#materialSideSubject.next(
       this.#material.toggleDoubleSide()
     );
+    this.forceReRender = true;
   }
 
   /**
@@ -258,6 +259,7 @@ export class CanvasService {
     cam.updateProjectionMatrix();
 
     this.#renderer.setSize(width, height);
+    this.forceReRender = true;
   }
 
   render$() {
@@ -270,7 +272,14 @@ export class CanvasService {
   }
 
   #wasAnimatingCompass = false;
+  forceReRender = false;
 
+  /**
+   * If {@link forceReRender} is true OR any scene descendant has {@link Object3D#matrixWorldNeedsUpdate}
+   * then we will render the scene.
+   *
+   * (First internally checks if the compass needs to render too).
+   */
   render() {
     if (!this.#renderer) { return false; }
 
@@ -279,6 +288,7 @@ export class CanvasService {
     if (this.#compass?.animating) {
       this.#compass.update(delta);
       this.#wasAnimatingCompass = true;
+      this.forceReRender = true;
     } else {
       if (this.#wasAnimatingCompass) {
         // just finished animating
@@ -290,9 +300,14 @@ export class CanvasService {
       this.#wasAnimatingCompass = false;
     }
 
-    this.#renderer.clear();
-    this.#renderer.render(this.#scene, this.#orthoCamera!);
-    this.#compass?.render(this.#renderer);
+    if (this.forceReRender || traverseSome(this.#scene, o => o.matrixWorldNeedsUpdate)) {
+      console.count('didRender');
+      this.#renderer.clear();
+      this.#renderer.render(this.#scene, this.#orthoCamera!);
+      this.#compass?.render(this.#renderer);
+
+      this.forceReRender = false;
+    }
 
     return true;
   }

--- a/src/app/shared/services/tools/cross-section-tool.service.ts
+++ b/src/app/shared/services/tools/cross-section-tool.service.ts
@@ -278,6 +278,7 @@ export class CrossSectionToolService extends BaseExclusiveToolService {
         this.#preview.origin,
         this.#preview.dest,
       ]);
+      this.#preview.lineAnno.object.matrixWorldNeedsUpdate = true;
 
     } else {
       const group = this.#currentModelRef?.deref();
@@ -310,8 +311,6 @@ export class CrossSectionToolService extends BaseExclusiveToolService {
         dest: destPoint,
         lineAnno,
       };
-
-
 
       group.addAnnotation(lineAnno);
     }


### PR DESCRIPTION
Resolves #14 .

Goals:
- [x] significant performance improvement when nothing is changing

Core Feature:
The main render loop only renders when any of the following conditions are met
   - `#scene` or any descendant has `matrixWorldNeedsUpdate` set. This fulfills 90% of cases without any additional work.
   - `forceReRender` is set to true
   - the compass is `animating`

This render loop optimization drops the ambient CPU usage of the largest test model from 20% to 3%, and almost all of the remaining 3% is overhead around `animationFrames()`

Additional features:
 * Introduced `ControlViewHelper`, a fork of Three.js's [ViewHelper](https://github.com/mrdoob/three.js/blob/de6dd45d7e5aa58fed0fbc1dbe53def3402b39cc/examples/jsm/helpers/ViewHelper.js), rewritten with class fields and methods.