### PR TITLE
Improve ortho view helper

### DIFF
--- a/src/app/shared/functions/normalize-canvas-coords.ts
+++ b/src/app/shared/functions/normalize-canvas-coords.ts
@@ -1,0 +1,20 @@
+import { Vector2 } from "three";
+
+const m2 = new Vector2(2, -2);
+const a1 = new Vector2(-1, 1);
+
+/**
+ * Convert canvas coordinates to... whatever these weird coordinates are.
+ */
+export function normalizeCanvasCoords(
+  globalCoords: Vector2,
+  globalDimensions: Vector2,
+  subsetDimensions = globalDimensions,
+  subsetOffset: Vector2 = new Vector2(),
+) {
+  return globalCoords.clone()
+    .sub(subsetOffset)
+    .divide(subsetDimensions)
+    .multiply(m2)
+    .add(a1);
+}

--- a/src/app/shared/models/objects/control-view-helper.ts
+++ b/src/app/shared/models/objects/control-view-helper.ts
@@ -85,8 +85,8 @@ export class ControlViewHelper<TControls extends ICameraControl> extends Object3
     const color3 = new Color('#2c8fff');
 
     this.#orthoCamera.position.set(0, 0, 2);
-    this.#orthoCamera.updateMatrix(); // Not in original implementation
-    this.#orthoCamera.updateMatrixWorld(true); // Not in original implementation
+    this.#orthoCamera.updateMatrix();
+    this.#orthoCamera.updateMatrixWorld(true);
 
     this.#xAxis = new Mesh(this.#geometry, this.#getAxisMaterial(color1));
     this.#yAxis = new Mesh(this.#geometry, this.#getAxisMaterial(color2));
@@ -245,7 +245,7 @@ export class ControlViewHelper<TControls extends ICameraControl> extends Object3
       const intersection = intersects[0];
       const object = intersection.object;
 
-      this.#prepareAnimationData(object, this.#worldControls.target);// this.center);
+      this.#prepareAnimationData(object, this.#worldControls.target);
 
       this.#animating = true;
 
@@ -268,7 +268,7 @@ export class ControlViewHelper<TControls extends ICameraControl> extends Object3
     // animate position by doing a slerp and then scaling the position on the unit sphere
 
     q1.rotateTowards(q2, step);
-    camera.position.set(0, 0, 1).applyQuaternion(q1).multiplyScalar(this.#radius).add(this.#worldControls.target); //this.center);
+    camera.position.set(0, 0, 1).applyQuaternion(q1).multiplyScalar(this.#radius).add(this.#worldControls.target);
     camera.updateMatrixWorld(true);
 
     // animate orientation

--- a/src/app/shared/models/objects/control-view-helper.ts
+++ b/src/app/shared/models/objects/control-view-helper.ts
@@ -1,6 +1,5 @@
 import {
   BoxGeometry,
-  Camera,
   CanvasTexture,
   Color,
   Euler,
@@ -17,7 +16,6 @@ import {
   Vector4,
   WebGLRenderer
 } from 'three';
-import { OrthographicMapControls } from './orthographic-map-controls';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 
 /**
@@ -44,7 +42,6 @@ export class ControlViewHelper extends Object3D {
 
   readonly #interactiveObjects: Sprite[] = [];
   readonly #raycaster = new Raycaster();
-  readonly #mouse = new Vector2();
   readonly #dummy = new Object3D();
 
   readonly #posXAxisHelper: Sprite;
@@ -209,7 +206,7 @@ export class ControlViewHelper extends Object3D {
     if (this.#animating === true) return false;
 
     const domElement = this.#domElement;
-    const mouse = this.#mouse;
+    const mouse = new Vector2();
 
     const rect = domElement.getBoundingClientRect();
     const offsetX = rect.left + (domElement.offsetWidth - this.#dim);
@@ -226,7 +223,7 @@ export class ControlViewHelper extends Object3D {
       const intersection = intersects[0];
       const object = intersection.object;
 
-      this.#prepareAnimationData(object, this.center);
+      this.#prepareAnimationData(object, this.#worldControls.target);// this.center);
 
       this.#animating = true;
 
@@ -249,7 +246,7 @@ export class ControlViewHelper extends Object3D {
     // animate position by doing a slerp and then scaling the position on the unit sphere
 
     q1.rotateTowards(q2, step);
-    camera.position.set(0, 0, 1).applyQuaternion(q1).multiplyScalar(this.#radius).add(this.center);
+    camera.position.set(0, 0, 1).applyQuaternion(q1).multiplyScalar(this.#radius).add(this.#worldControls.target); //this.center);
     camera.updateMatrixWorld(true);
 
     // animate orientation

--- a/src/app/shared/models/objects/control-view-helper.ts
+++ b/src/app/shared/models/objects/control-view-helper.ts
@@ -16,7 +16,7 @@ import {
   Vector4,
   WebGLRenderer
 } from 'three';
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
+import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import { normalizeCanvasCoords } from '../../functions/normalize-canvas-coords';
 
 /**
@@ -25,8 +25,8 @@ import { normalizeCanvasCoords } from '../../functions/normalize-canvas-coords';
  *
  * but not reliant on auto updated matrices.
  */
-export class ControlViewHelper extends Object3D {
-  #worldControls: OrbitControls;
+export class ControlViewHelper<TControls extends OrbitControls> extends Object3D {
+  #worldControls: TControls;
   readonly #domElement: HTMLElement;
 
   readonly isViewHelper = true;
@@ -69,7 +69,7 @@ export class ControlViewHelper extends Object3D {
   readonly #q2 = new Quaternion();
   #radius = 0;
 
-  constructor(controls: OrbitControls, domElement: HTMLElement) {
+  constructor(controls: TControls, domElement: HTMLElement) {
     super();
 
     this.#worldControls = controls;
@@ -134,7 +134,7 @@ export class ControlViewHelper extends Object3D {
     this.traverse(c => c.updateMatrix());
   }
 
-  changeControls(controls: OrbitControls) {
+  changeControls(controls: TControls) {
     this.#worldControls = controls;
   }
 

--- a/src/app/shared/models/objects/control-view-helper.ts
+++ b/src/app/shared/models/objects/control-view-helper.ts
@@ -205,27 +205,31 @@ export class ControlViewHelper extends Object3D {
   /**
    * Handle a click into the box representing the control view helper.
    */
-  handleClick(event: MouseEvent) {
+  handleClick(event: MouseEvent, clickWasOnGlobalCanvas = false) {
 
     if (this.#animating === true) return false;
 
-    // const rect = domElement.getBoundingClientRect();
-    // const offset = new Vector2(rect.left, rect.top)
-    //   .add(new Vector2(domElement.offsetWidth, domElement.offsetHeight))
-    //   .subScalar(this.#dim);
-
-    // const mouse = new Vector2(event.clientX, event.clientY)
-    //   .sub(offset)
-    //   .divide(new Vector2(rect.right, rect.bottom).sub(offset))
-    //   .multiply(new Vector2(2, -2))
-    //   .add(new Vector2(-1, 1));
+    let mouse: Vector2;
 
     const myDim = new Vector2(this.#dim, this.#dim);
+    if (!clickWasOnGlobalCanvas) {
+      mouse = normalizeCanvasCoords(
+        new Vector2(event.offsetX, event.offsetY),
+        myDim,
+      );
+    } else {
+      const domElement = this.#domElement;
+      const domDim = new Vector2(domElement.offsetWidth, domElement.offsetHeight);
+      const myDim = new Vector2(this.#dim, this.#dim);
+      const myOffset = domDim.clone().sub(myDim);
 
-    const mouse = normalizeCanvasCoords(
-      new Vector2(event.offsetX, event.offsetY),
-      myDim,
-    );
+      mouse = normalizeCanvasCoords(
+        new Vector2(event.offsetX, event.offsetY),
+        domDim,
+        myDim,
+        myOffset,
+      );
+    }
 
     this.#raycaster.setFromCamera(mouse, this.#orthoCamera);
 

--- a/src/app/shared/models/objects/control-view-helper.ts
+++ b/src/app/shared/models/objects/control-view-helper.ts
@@ -17,6 +17,7 @@ import {
   WebGLRenderer
 } from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
+import { normalizeCanvasCoords } from '../../functions/normalize-canvas-coords';
 
 /**
  * Copy of Three.JS's
@@ -201,18 +202,30 @@ export class ControlViewHelper extends Object3D {
 
   };
 
+  /**
+   * Handle a click into the box representing the control view helper.
+   */
   handleClick(event: MouseEvent) {
 
     if (this.#animating === true) return false;
 
-    const domElement = this.#domElement;
-    const mouse = new Vector2();
+    // const rect = domElement.getBoundingClientRect();
+    // const offset = new Vector2(rect.left, rect.top)
+    //   .add(new Vector2(domElement.offsetWidth, domElement.offsetHeight))
+    //   .subScalar(this.#dim);
 
-    const rect = domElement.getBoundingClientRect();
-    const offsetX = rect.left + (domElement.offsetWidth - this.#dim);
-    const offsetY = rect.top + (domElement.offsetHeight - this.#dim);
-    mouse.x = ((event.clientX - offsetX) / (rect.right - offsetX)) * 2 - 1;
-    mouse.y = - ((event.clientY - offsetY) / (rect.bottom - offsetY)) * 2 + 1;
+    // const mouse = new Vector2(event.clientX, event.clientY)
+    //   .sub(offset)
+    //   .divide(new Vector2(rect.right, rect.bottom).sub(offset))
+    //   .multiply(new Vector2(2, -2))
+    //   .add(new Vector2(-1, 1));
+
+    const myDim = new Vector2(this.#dim, this.#dim);
+
+    const mouse = normalizeCanvasCoords(
+      new Vector2(event.offsetX, event.offsetY),
+      myDim,
+    );
 
     this.#raycaster.setFromCamera(mouse, this.#orthoCamera);
 
@@ -374,3 +387,4 @@ export class ControlViewHelper extends Object3D {
   }
 
 }
+

--- a/src/app/shared/models/objects/control-view-helper.ts
+++ b/src/app/shared/models/objects/control-view-helper.ts
@@ -1,5 +1,6 @@
 import {
   BoxGeometry,
+  type Camera,
   CanvasTexture,
   Color,
   Euler,
@@ -14,10 +15,14 @@ import {
   Vector2,
   Vector3,
   Vector4,
-  WebGLRenderer
+  type WebGLRenderer
 } from 'three';
-import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import { normalizeCanvasCoords } from '../../functions/normalize-canvas-coords';
+
+export interface ICameraControl<TCamera extends Camera = Camera> {
+  readonly camera: TCamera;
+  readonly target: Vector3;
+}
 
 /**
  * Copy of Three.JS's
@@ -25,7 +30,7 @@ import { normalizeCanvasCoords } from '../../functions/normalize-canvas-coords';
  *
  * but not reliant on auto updated matrices.
  */
-export class ControlViewHelper<TControls extends OrbitControls> extends Object3D {
+export class ControlViewHelper<TControls extends ICameraControl> extends Object3D {
   #worldControls: TControls;
   readonly #domElement: HTMLElement;
 
@@ -144,12 +149,12 @@ export class ControlViewHelper<TControls extends OrbitControls> extends Object3D
     const dim = this.#dim;
     const viewport = this.#viewport;
 
-    this.quaternion.copy(this.#worldControls.object.quaternion).invert();
+    this.quaternion.copy(this.#worldControls.camera.quaternion).invert();
     this.updateMatrix();
     this.updateMatrixWorld(true);
 
     point.set(0, 0, 1);
-    point.applyQuaternion(this.#worldControls.object.quaternion);
+    point.applyQuaternion(this.#worldControls.camera.quaternion);
 
     if (point.x >= 0) {
 
@@ -256,7 +261,7 @@ export class ControlViewHelper<TControls extends OrbitControls> extends Object3D
 
     const q1 = this.#q1;
     const q2 = this.#q2;
-    const camera = this.#worldControls.object;
+    const camera = this.#worldControls.camera;
 
     const step = delta * this.#turnRate;
 
@@ -343,12 +348,12 @@ export class ControlViewHelper<TControls extends OrbitControls> extends Object3D
 
     //
 
-    this.#radius = this.#worldControls.object.position.distanceTo(focusPoint);
+    this.#radius = this.#worldControls.camera.position.distanceTo(focusPoint);
     this.#targetPosition.multiplyScalar(this.#radius).add(focusPoint);
 
     this.#dummy.position.copy(focusPoint);
 
-    this.#dummy.lookAt(this.#worldControls.object.position);
+    this.#dummy.lookAt(this.#worldControls.camera.position);
     this.#q1.copy(this.#dummy.quaternion);
 
     this.#dummy.lookAt(this.#targetPosition);

--- a/src/app/shared/models/objects/orthographic-map-controls.ts
+++ b/src/app/shared/models/objects/orthographic-map-controls.ts
@@ -1,0 +1,9 @@
+import { OrthographicCamera } from "three";
+import { MapControls } from "three/examples/jsm/controls/MapControls"
+
+export class OrthographicMapControls extends MapControls {
+  override object!: OrthographicCamera;
+  constructor(cam: OrthographicCamera, domElement: HTMLElement) {
+    super(cam, domElement);
+  }
+}

--- a/src/app/shared/models/objects/orthographic-map-controls.ts
+++ b/src/app/shared/models/objects/orthographic-map-controls.ts
@@ -1,4 +1,4 @@
-import { OrthographicCamera } from "three";
+import type { OrthographicCamera } from "three";
 import { MapControls } from "three/examples/jsm/controls/MapControls"
 
 export class OrthographicMapControls extends MapControls {

--- a/src/app/shared/models/objects/orthographic-map-controls.ts
+++ b/src/app/shared/models/objects/orthographic-map-controls.ts
@@ -2,7 +2,10 @@ import { OrthographicCamera } from "three";
 import { MapControls } from "three/examples/jsm/controls/MapControls"
 
 export class OrthographicMapControls extends MapControls {
-  override object!: OrthographicCamera;
+  get camera() {
+    return this.object as OrthographicCamera;
+  }
+
   constructor(cam: OrthographicCamera, domElement: HTMLElement) {
     super(cam, domElement);
   }

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -2,17 +2,16 @@ import { Injectable, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, Observable, Subject, animationFrames, defer, distinctUntilChanged, filter, fromEvent, map, scan, switchMap, takeUntil, tap } from 'rxjs';
 import { AmbientLight, Box3, Camera, Clock, FrontSide, GridHelper, Material, OrthographicCamera, Raycaster, Scene, Side, Vector2, Vector3, WebGLRenderer } from 'three';
-import { MapControls } from 'three/examples/jsm/controls/MapControls.js';
 import { traverseSome } from '../functions/traverse-some';
 import { ModelChangeType } from '../models/model-change-type.enum';
 import { ControlViewHelper } from '../models/objects/control-view-helper';
+import { OrthographicMapControls } from '../models/objects/orthographic-map-controls';
 import { GroupRenderModel } from '../models/render/group.render-model';
 import { ignoreNullish } from '../operators/ignore-nullish';
 import { BaseMaterialService } from './3d-managers/base-material.service';
 import { MeshNormalMaterialService } from './3d-managers/mesh-normal-material.service';
 import { LocalizeService } from './localize.service';
 import { ModelManagerService } from './model-manager.service';
-import { OrthographicMapControls } from '../models/objects/orthographic-map-controls';
 
 @Injectable()
 export class CanvasService {
@@ -279,7 +278,6 @@ export class CanvasService {
     );
   }
 
-  #wasAnimatingCompass = false;
   forceReRender = false;
 
   /**
@@ -295,19 +293,7 @@ export class CanvasService {
 
     if (this.#compass.animating) {
       this.#compass.update(delta);
-      this.#wasAnimatingCompass = true;
       this.forceReRender = true;
-    } else {
-      if (this.#wasAnimatingCompass) {
-        // just finished animating
-        // I CANNOT figure out why I can't just update controls, but I seem to need to rebuild
-        const cam = this.#orthoControls.object;
-        this.#orthoControls.dispose();
-        this.#orthoControls = new OrthographicMapControls(cam, this.#renderer.domElement);
-        this.#compass.changeControls(this.#orthoControls);
-      }
-
-      this.#wasAnimatingCompass = false;
     }
 
     if (this.forceReRender || traverseSome(this.#scene, o => o.matrixWorldNeedsUpdate)) {

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -259,7 +259,7 @@ export class CanvasService {
       throw new Error('Attempt to resize() with no renderer');
     }
 
-    const cam = this.#orthoControls.object;
+    const cam = this.#orthoControls.camera;
     cam.left = - width / 2;
     cam.right = width / 2;
     cam.top = height / 2;

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -37,7 +37,7 @@ export class CanvasService {
   #orthoControls?: OrthographicMapControls;
 
   readonly #compassDivSubject = new BehaviorSubject<HTMLElement | undefined>(undefined);
-  #compass?: ControlViewHelper;
+  #compass?: ControlViewHelper<OrthographicMapControls>;
 
   readonly #meshNormalMaterial = inject(MeshNormalMaterialService);
   #material: BaseMaterialService<Material> = this.#meshNormalMaterial;

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -103,11 +103,11 @@ export class CanvasService {
     }
 
     const cameraToOldPointVector = new Vector3();
-    cameraToOldPointVector.subVectors(this.#orthoControls.object.position, this.#orthoControls.target);
+    cameraToOldPointVector.subVectors(this.#orthoControls.camera.position, this.#orthoControls.target);
 
     const newCameraLoc = point.clone().add(cameraToOldPointVector);
 
-    this.#orthoControls.object.position.copy(newCameraLoc);
+    this.#orthoControls.camera.position.copy(newCameraLoc);
     this.#orthoControls.target.copy(point);
     this.#orthoControls.update();
   }
@@ -158,7 +158,7 @@ export class CanvasService {
     const { x: width, y: height } = dimensions.multiplyScalar(sizeMultiplier);
 
     const sceneCopy = this.#scene.clone(true);
-    const camera = cam ?? this.#orthoControls?.object;
+    const camera = cam ?? this.#orthoControls?.camera;
 
     if (!camera) {
       throw new Error('Could not find camera in sceneCopy');
@@ -228,7 +228,7 @@ export class CanvasService {
   }
 
   raycastFromCamera(coords: Vector2) {
-    this.#raycaster.setFromCamera(coords, this.#orthoControls!.object);
+    this.#raycaster.setFromCamera(coords, this.#orthoControls!.camera);
 
     return this.#raycaster.intersectObjects(this.#scene.children, true);
   }
@@ -300,7 +300,7 @@ export class CanvasService {
     if (this.forceReRender || traverseSome(this.#scene, o => o.matrixWorldNeedsUpdate)) {
       console.count('didRender');
       this.#mainRenderer.clear();
-      this.#mainRenderer.render(this.#scene, this.#orthoControls.object);
+      this.#mainRenderer.render(this.#scene, this.#orthoControls.camera);
       this.#compass.render(this.#mainRenderer);
 
       this.forceReRender = false;
@@ -324,7 +324,7 @@ export class CanvasService {
       return;
     }
 
-    controls.object.position.set(
+    controls.camera.position.set(
       0,
       bounds.max.y + 5,
       0.0000001 // sliiightly offset the Z so we (should) always look from Z when reseting controls

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -289,11 +289,11 @@ export class CanvasService {
    * (First internally checks if the compass needs to render too).
    */
   render() {
-    if (!this.#renderer || !this.#orthoControls) { return false; }
+    if (!this.#renderer || !this.#orthoControls || !this.#compass) { return false; }
 
     const delta = this.#renderClock.getDelta();
 
-    if (this.#compass?.animating) {
+    if (this.#compass.animating) {
       this.#compass.update(delta);
       this.#wasAnimatingCompass = true;
       this.forceReRender = true;
@@ -304,6 +304,7 @@ export class CanvasService {
         const cam = this.#orthoControls.object;
         this.#orthoControls.dispose();
         this.#orthoControls = new OrthographicMapControls(cam, this.#renderer.domElement);
+        this.#compass.changeControls(this.#orthoControls);
       }
 
       this.#wasAnimatingCompass = false;
@@ -313,7 +314,7 @@ export class CanvasService {
       console.count('didRender');
       this.#renderer.clear();
       this.#renderer.render(this.#scene, this.#orthoControls.object);
-      this.#compass?.render(this.#renderer);
+      this.#compass.render(this.#renderer);
 
       this.forceReRender = false;
     }
@@ -444,7 +445,7 @@ export class CanvasService {
         if (!ele || !this.#orthoControls || !this.#renderer?.domElement) {
           return undefined;
         }
-        const compass = new ControlViewHelper(this.#orthoControls.object, this.#renderer.domElement);
+        const compass = new ControlViewHelper(this.#orthoControls, this.#renderer.domElement);
         ele.addEventListener('pointerup', e => compass.handleClick(e));
         this.#compass = compass;
         return compass;

--- a/src/app/shared/services/tools/base-tool.service.ts
+++ b/src/app/shared/services/tools/base-tool.service.ts
@@ -1,6 +1,5 @@
 import { InjectionToken } from "@angular/core";
 import { Observable, of } from "rxjs";
-import { Vector2 } from "three";
 
 export const EXCLUSIVE_TOOL_SERVICES = new InjectionToken<readonly BaseExclusiveToolService[]>('exclusive-tool-services');
 export const NONEXCLUSIVE_TOOL_SERVICES = new InjectionToken<readonly BaseClickToolService[]>('non-exclusive-tool-services');
@@ -25,16 +24,4 @@ export abstract class BaseExclusiveToolService extends BaseToolService {
 
   abstract start(): boolean;
   abstract stop(): boolean;
-
-  /**
-   * I still don't fully understand why this is needed, but convert the
-   * pointer event offset coordinates to ThreeJS canvas coordinates.
-   */
-  normalizeCanvasCoords(offsetCoords: Vector2, dimensions: Vector2) {
-    return offsetCoords
-      .clone()
-      .divide(dimensions)
-      .multiply(new Vector2(2, -2))
-      .add(new Vector2(-1, 1));
-  }
 }

--- a/src/app/shared/services/tools/cross-section-tool.service.ts
+++ b/src/app/shared/services/tools/cross-section-tool.service.ts
@@ -261,7 +261,6 @@ export class CrossSectionToolService extends BaseExclusiveToolService {
     const targetCoords = new Vector2(e.offsetX, e.offsetY);
     const dimensions = this.#canvasService.getRendererDimensions()!;
 
-    // const mouseWorldPos = this.normalizeCanvasCoords(targetCoords, dimensions);
     const mouseWorldPos = normalizeCanvasCoords(targetCoords, dimensions);
 
     const casts = this.#canvasService.raycastFromCamera(mouseWorldPos);

--- a/src/app/shared/services/tools/cross-section-tool.service.ts
+++ b/src/app/shared/services/tools/cross-section-tool.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, Subject, distinctUntilChanged, filter, merge, switchMap, takeUntil, tap } from 'rxjs';
 import { BufferGeometry, GridHelper, Intersection, Line, LineBasicMaterial, Vector2, Vector3 } from 'three';
+import { normalizeCanvasCoords } from '../../functions/normalize-canvas-coords';
 import { CrossSectionAnnotation } from '../../models/annotations/cross-section.annotation';
 import { TemporaryAnnotation } from '../../models/annotations/temporary.annotation';
 import { GroupRenderModel } from '../../models/render/group.render-model';
@@ -260,7 +261,8 @@ export class CrossSectionToolService extends BaseExclusiveToolService {
     const targetCoords = new Vector2(e.offsetX, e.offsetY);
     const dimensions = this.#canvasService.getRendererDimensions()!;
 
-    const mouseWorldPos = this.normalizeCanvasCoords(targetCoords, dimensions);
+    // const mouseWorldPos = this.normalizeCanvasCoords(targetCoords, dimensions);
+    const mouseWorldPos = normalizeCanvasCoords(targetCoords, dimensions);
 
     const casts = this.#canvasService.raycastFromCamera(mouseWorldPos);
 

--- a/src/app/shared/services/tools/distance-measure-tool.service.ts
+++ b/src/app/shared/services/tools/distance-measure-tool.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, Subject, distinctUntilChanged, map, of, take, takeUntil, tap } from 'rxjs';
 import { Group, Intersection, Mesh, Object3D, Vector2, Vector3 } from 'three';
+import { normalizeCanvasCoords } from '../../functions/normalize-canvas-coords';
 import { MeasureDistanceAnnotation } from '../../models/annotations/measure-distance.annotation';
 import { IMapperUserData } from '../../models/user-data';
 import { ignoreNullish } from '../../operators/ignore-nullish';
@@ -146,7 +147,8 @@ export class DistanceMeasureToolService extends BaseExclusiveToolService {
         const targetCoords = new Vector2(e.offsetX, e.offsetY);
         const dimensions = this.#canvasService.getRendererDimensions()!;
 
-        const mouseWorldPos = this.normalizeCanvasCoords(targetCoords, dimensions);
+        // const mouseWorldPos = this.normalizeCanvasCoords(targetCoords, dimensions);
+        const mouseWorldPos = normalizeCanvasCoords(targetCoords, dimensions);
 
         this.#handleNewMeasurementLocation(mouseWorldPos);
       })

--- a/src/app/shared/services/tools/distance-measure-tool.service.ts
+++ b/src/app/shared/services/tools/distance-measure-tool.service.ts
@@ -147,7 +147,6 @@ export class DistanceMeasureToolService extends BaseExclusiveToolService {
         const targetCoords = new Vector2(e.offsetX, e.offsetY);
         const dimensions = this.#canvasService.getRendererDimensions()!;
 
-        // const mouseWorldPos = this.normalizeCanvasCoords(targetCoords, dimensions);
         const mouseWorldPos = normalizeCanvasCoords(targetCoords, dimensions);
 
         this.#handleNewMeasurementLocation(mouseWorldPos);


### PR DESCRIPTION
Goals
- [x] resolve #19 by switching ViewHelper/compass to use controls instead of camera, and stay focused on the current focus point

Features:
* `ControlViewHelper` takes any control that has a `camera` and `target` property, and changes the camera relative to the target rather than relative to the origin.
   - this also significantly simplified `render()` because the controls are being updated properly and we don't need `#wasAnimatingCompass`
* Introduce `OrthographicMapControls extends MapControls` which just adds the property `camera` to be consistent with other controls...

Additional changes:
* resolve #20 ; issue first found by user but core problem found by @uhuh; (cross-section) subrenderers are disposed but did not seem to release their WebGL context, leading Chrome to dispose the _oldest_ context which is always the main renderer, leading to blank screen
* moved coord normalization (or whatever it is) to `normalizeCanvasCoords()` for reuse in a few places.
* renamed `#renderer` and `rendererSymbol` to refer `#mainRenderer` to clarify