### PR TITLE
App shell

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -51,7 +51,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kb",
-                  "maximumError": "8mb"
+                  "maximumError": "1mb"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -27,7 +27,17 @@
       "resources": {
         "files": [
           "/assets/**",
+          "!/assets/files",
           "/media/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)"
+        ]
+      }
+    },
+    {
+      "name": "third-party",
+      "installMode": "prefetch",
+      "resources": {
+        "urls": [
+          "https://fonts.googleapis.com"
         ]
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavern-seer-mapper",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "homepage": "https://github.com/skgrush/cavern-seer-mapper#readme",
   "license": "MIT",
   "author": {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,10 +1,8 @@
-<div class="drop-overlay">
-  <div class="drop-overlay-inner">Drop files here</div>
-</div>
-
 <mat-sidenav-container>
   <mat-sidenav #leftMenu id="left-sidenav">
-    <mapper-sidenav (buttonClicked)="leftMenu.close()" />
+    <!-- <mapper-sidenav (buttonClicked)="leftMenu.close()" /> -->
+    <!-- TODO: re-add buttonClick logic -->
+    <router-outlet name="left-side-nav" />
   </mat-sidenav>
 
   <mat-sidenav-content>
@@ -17,13 +15,12 @@
         {{ rightTabNav.opened ? 'chevron_right' : 'chevron_left' }}
       </mat-icon>
     </button>
-    <mapper-tools-bar />
-    <mapper-compass />
-    <mapper-canvas />
-    <mapper-file-url-loader />
+
+    <router-outlet name="main" />
   </mat-sidenav-content>
 
   <mat-sidenav #rightTabNav mode="side" position="end" id="right-sidenav">
-    <mapper-right-tab-nav />
+    <router-outlet name="right-tab-nav" />
+    <!-- <mapper-right-tab-nav /> -->
   </mat-sidenav>
 </mat-sidenav-container>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -3,32 +3,7 @@
   width: 100%;
   height: 100%;
 
-  .drop-overlay {
-    display: none;
-  }
 
-  &.file-is-dragging-over .drop-overlay {
-    display: grid;
-    align-items: stretch;
-    justify-items: stretch;
-
-    user-select: none;
-
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    z-index: 2;
-
-    background: rgba(255, 255, 255, 0.5);
-
-    .drop-overlay-inner {
-      display: grid;
-      align-items: center;
-      justify-content: center;
-      margin: 1em;
-      border: 1em dashed;
-    }
-  }
 
   mat-sidenav-container {
     width: 100%;
@@ -36,48 +11,23 @@
 
     mat-sidenav-content {
       display: grid;
-      grid-template-areas: 'main';
+      grid-template-areas: 'app-main';
       overflow: hidden;
 
       &>#open-leftmenu-btn {
-        grid-area: main;
+        grid-area: app-main;
         margin: 1em;
       }
 
       &>#open-righttabnav-btn {
-        grid-area: main;
+        grid-area: app-main;
         justify-self: end;
         align-self: start;
         margin: 1em;
       }
 
-      &>mapper-tools-bar {
-        grid-area: main;
-        justify-self: center;
-        align-self: end;
-        margin-bottom: 1em;
-        z-index: 2;
-      }
-
-      &>mapper-canvas {
-        grid-area: main;
-        justify-self: stretch;
-        align-self: stretch;
-        overflow: hidden;
-      }
-
-      &>mapper-compass {
-        grid-area: main;
-        justify-self: end;
-        align-self: end;
-        z-index: 1;
-      }
-
-      &>mapper-file-url-loader {
-        grid-area: main;
-        justify-self: center;
-        align-self: center;
-        z-index: 1;
+      &>router-outlet {
+        display: none;
       }
     }
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,16 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, HostBinding, HostListener, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { CanvasComponent } from "./pages/canvas/canvas.component";
-import { FileUrlLoaderComponent } from "./pages/file-url-loader/file-url-loader.component";
-import { RightTabNavComponent } from "./pages/right-tab-nav/right-tab-nav.component";
-import { CompassComponent } from "./shared/components/compass/compass.component";
-import { SidenavComponent } from "./shared/components/sidenav/sidenav.component";
-import { ToolsBarComponent } from './shared/components/tools-bar/tools-bar.component';
-import { DialogOpenerService } from './shared/services/dialog-opener.service';
+import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'mapper-root',
@@ -18,62 +12,19 @@ import { DialogOpenerService } from './shared/services/dialog-opener.service';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, CanvasComponent, MatSidenavModule, MatButtonModule, MatIconModule, SidenavComponent, ToolsBarComponent, RightTabNavComponent, CompassComponent, MatTooltipModule, FileUrlLoaderComponent]
+  imports: [CommonModule, RouterOutlet, MatSidenavModule, MatButtonModule, MatIconModule, MatTooltipModule]
 })
 export class AppComponent {
 
-  readonly #dialogOpener = inject(DialogOpenerService);
-
-  @HostBinding('class.file-is-dragging-over')
-  fileIsDraggingOver = false;
-
-  @HostListener('dragenter', ['$event'])
-  dragEnter(e: DragEvent) {
-    console.debug('dragenter', e);
-  }
-
-  /**
-   * @description
-   * when the overlay appears, this triggers, BUT it has a "relatedTarget".
-   * When the hover leaves the screen, "relatedTarget" is null.
-   */
-  @HostListener('dragleave', ['$event'])
-  dragLeave(e: DragEvent) {
-    const leavingWindow = !e.relatedTarget;
-    console.debug('dragleave', { leavingWindow });
-
-    if (leavingWindow) {
-      this.fileIsDraggingOver = false;
-    }
-  }
-
   @HostListener('dragover', ['$event'])
   dragOver(e: DragEvent) {
-    if (!e.dataTransfer) {
-      return;
-    }
-    if (e.dataTransfer.types.includes('Files')) {
-      console.debug('dragOver with files');
-      e.preventDefault();
-      this.fileIsDraggingOver = true;
-    }
-    else {
-      console.debug('dragOver non-files:', ...e.dataTransfer.types);
-    }
+    // prevent ANY form of file drop (that wasn't caught by a lower)
+    e.preventDefault();
   }
 
   @HostListener('drop', ['$event'])
   drop(e: DragEvent) {
+    console.info('drop on app', e);
     e.preventDefault();
-    this.fileIsDraggingOver = false;
-
-    const files = e.dataTransfer?.files;
-    if (!files?.length) {
-      return;
-    }
-
-    console.info('file drop', e, files);
-
-    this.#dialogOpener.import(files);
   }
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,55 +1,24 @@
 import { ApplicationConfig, ErrorHandler, LOCALE_ID, importProvidersFrom, isDevMode } from '@angular/core';
-import { provideRouter } from '@angular/router';
-
 import { MAT_SNACK_BAR_DEFAULT_OPTIONS, MatSnackBarConfig, MatSnackBarModule } from '@angular/material/snack-bar';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
 import { provideServiceWorker } from '@angular/service-worker';
-import { provideStore } from '@ngrx/store';
+import versionObject from '../version.json';
 import { routes } from './app.routes';
-import { FileIconModule } from './shared/components/file-icon/file-icon.module';
-import { MeshNormalMaterialService } from './shared/services/3d-managers/mesh-normal-material.service';
 import { AlertService } from './shared/services/alert.service';
-import { AnnotationBuilderService } from './shared/services/annotation-builder.service';
-import { CanvasService } from './shared/services/canvas.service';
-import { DialogOpenerService } from './shared/services/dialog-opener.service';
 import { ErrorService } from './shared/services/error.service';
-import { ExportService } from './shared/services/export.service';
-import { FileTypeService } from './shared/services/file-type.service';
-import { LocalizeService } from './shared/services/localize.service';
-import { ModelLoadService } from './shared/services/model-load.service';
-import { ModelManagerService } from './shared/services/model-manager.service';
-import { ResizeService } from './shared/services/resize.service';
 import { ServiceWorkerService } from './shared/services/service-worker.service';
-import { provideSettings } from './shared/services/settings';
-import { ThemeService } from './shared/services/theme.service';
-import { ToolManagerService } from './shared/services/tool-manager.service';
-import { toolsProviders } from './shared/services/tools';
 import { INTL_COLLATOR } from './shared/tokens/intl-collator.token';
 import { INTL_LOCALE } from './shared/tokens/intl-locale.token';
 import { INTL_UNIT_LIST_FORMAT } from './shared/tokens/intl-unit-list-format.token';
 import { LOCAL_STORAGE } from './shared/tokens/local-storage.token';
 import { MAPPER_VERSION, VersionObject } from './shared/tokens/version.token';
-import versionObject from '../version.json';
 
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
     provideAnimations(),
-    provideStore(),
-    CanvasService,
-    ResizeService,
-    ExportService,
-    ThemeService,
-    importProvidersFrom(FileIconModule),
-    FileTypeService,
-    LocalizeService,
-    ModelLoadService,
-    ModelManagerService,
-    MeshNormalMaterialService,
-    ToolManagerService,
-    AnnotationBuilderService,
-    DialogOpenerService,
     ErrorService,
     AlertService,
     importProvidersFrom(MatSnackBarModule),
@@ -60,8 +29,6 @@ export const appConfig: ApplicationConfig = {
         duration: 5e3,
       } satisfies MatSnackBarConfig,
     },
-    toolsProviders(),
-    provideSettings(),
     { provide: MAPPER_VERSION, useValue: versionObject satisfies VersionObject },
     { provide: LOCALE_ID, useFactory: () => globalThis.navigator.language },
     { provide: INTL_LOCALE, useFactory: (locale: string) => new Intl.Locale(locale), deps: [LOCALE_ID] },
@@ -76,6 +43,6 @@ export const appConfig: ApplicationConfig = {
     provideServiceWorker('ngsw-worker.js', {
       enabled: !isDevMode(),
       registrationStrategy: 'registerWhenStable:30000'
-    })
+    }),
   ],
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,13 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    loadChildren: () => import('./deferred.routes'),
+  },
+  {
+    path: '**',
+    redirectTo: '',
+  }
+];

--- a/src/app/deferred.routes.ts
+++ b/src/app/deferred.routes.ts
@@ -1,0 +1,65 @@
+import { importProvidersFrom } from "@angular/core";
+import { Routes } from "@angular/router";
+import { provideStore } from "@ngrx/store";
+import { MainComponent } from "./pages/main/main.component";
+import { RightTabNavComponent } from "./pages/right-tab-nav/right-tab-nav.component";
+import { FileIconModule } from "./shared/components/file-icon/file-icon.module";
+import { SidenavComponent } from "./shared/components/sidenav/sidenav.component";
+import { MeshNormalMaterialService } from "./shared/services/3d-managers/mesh-normal-material.service";
+import { AnnotationBuilderService } from "./shared/services/annotation-builder.service";
+import { CanvasService } from "./shared/services/canvas.service";
+import { DialogOpenerService } from "./shared/services/dialog-opener.service";
+import { ExportService } from "./shared/services/export.service";
+import { FileTypeService } from "./shared/services/file-type.service";
+import { LocalizeService } from "./shared/services/localize.service";
+import { ModelLoadService } from "./shared/services/model-load.service";
+import { ModelManagerService } from "./shared/services/model-manager.service";
+import { ResizeService } from "./shared/services/resize.service";
+import { provideSettings } from "./shared/services/settings";
+import { ThemeService } from "./shared/services/theme.service";
+import { ToolManagerService } from "./shared/services/tool-manager.service";
+import { toolsProviders } from "./shared/services/tools";
+
+const deferredRoutes: Routes = [
+  {
+    path: '',
+    children: [
+      {
+        path: '',
+        outlet: 'main',
+        component: MainComponent,
+      },
+      {
+        path: '',
+        outlet: 'left-side-nav',
+        component: SidenavComponent,
+      },
+      {
+        path: '',
+        outlet: 'right-tab-nav',
+        component: RightTabNavComponent,
+      }
+    ],
+    providers: [
+      provideStore(),
+      CanvasService,
+      ResizeService,
+      ExportService,
+      ThemeService,
+      importProvidersFrom(FileIconModule),
+      FileTypeService,
+      LocalizeService,
+      ModelLoadService,
+      ModelManagerService,
+      MeshNormalMaterialService,
+      ToolManagerService,
+      AnnotationBuilderService,
+      DialogOpenerService,
+
+      toolsProviders(),
+      provideSettings(),
+    ]
+  }
+];
+
+export default deferredRoutes;

--- a/src/app/dialogs/cross-section-render-dialog/cross-section-render-dialog.component.ts
+++ b/src/app/dialogs/cross-section-render-dialog/cross-section-render-dialog.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe, NgIf } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, Injector, ViewChild, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
@@ -32,6 +32,8 @@ export class CrossSectionRenderDialogComponent implements AfterViewInit {
   canvasElement!: ElementRef<HTMLCanvasElement>;
 
   readonly #destroyRef = inject(DestroyRef);
+  readonly #injector = inject(Injector);
+
   readonly #canvasService = inject(CanvasService);
   readonly #dialog = inject(MatDialog);
   readonly #errorService = inject(ErrorService);
@@ -40,12 +42,14 @@ export class CrossSectionRenderDialogComponent implements AfterViewInit {
 
   static open(
     dialog: MatDialog,
+    injector: Injector,
     data: ICrossSectionRenderDialogData,
   ) {
     return dialog.open<CrossSectionRenderDialogComponent, ICrossSectionRenderDialogData>(
       CrossSectionRenderDialogComponent,
       {
         data,
+        injector,
       },
     );
   }
@@ -126,6 +130,7 @@ export class CrossSectionRenderDialogComponent implements AfterViewInit {
       switchMap(({ ExportImageDialogComponent }) => {
         return ExportImageDialogComponent.open(
           this.#dialog,
+          this.#injector,
           {
             titleText: `Export cross-section ${this.crossSection.identifier}`,
             camera,

--- a/src/app/dialogs/export-image-dialog/export-image-dialog.component.ts
+++ b/src/app/dialogs/export-image-dialog/export-image-dialog.component.ts
@@ -1,16 +1,16 @@
-import { NgIf, AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { AsyncPipe, NgIf } from '@angular/common';
+import { ChangeDetectionStrategy, Component, Injector, inject } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { ExportService } from '../../shared/services/export.service';
-import { CanvasService } from '../../shared/services/canvas.service';
 import { BehaviorSubject, tap } from 'rxjs';
-import { MatButtonToggleModule } from '@angular/material/button-toggle';
-import { BytesPipe } from "../../shared/pipes/bytes.pipe";
 import type { Camera } from 'three';
+import { BytesPipe } from "../../shared/pipes/bytes.pipe";
+import { CanvasService } from '../../shared/services/canvas.service';
+import { ExportService } from '../../shared/services/export.service';
 
 export type IExportImageDialogData = {
   readonly titleText: string;
@@ -64,12 +64,14 @@ export class ExportImageDialogComponent {
 
   static open(
     dialog: MatDialog,
+    injector: Injector,
     data: IExportImageDialogData,
   ) {
     return dialog.open<ExportImageDialogComponent, IExportImageDialogData>(
       ExportImageDialogComponent,
       {
         data,
+        injector,
       },
     );
   }

--- a/src/app/dialogs/open-dialog/open-dialog.component.ts
+++ b/src/app/dialogs/open-dialog/open-dialog.component.ts
@@ -1,11 +1,12 @@
 import { AsyncPipe, NgFor, NgIf } from '@angular/common';
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, OnInit, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatListModule } from '@angular/material/list';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { BehaviorSubject, forkJoin } from 'rxjs';
 import { FileIconComponent } from '../../shared/components/file-icon/file-icon.component';
+import { AggregateError2 } from '../../shared/errors/aggregate.error';
 import { BaseRenderModel } from '../../shared/models/render/base.render-model';
 import { TransportProgressHandler } from '../../shared/models/transport-progress-handler';
 import { UploadFileModel } from '../../shared/models/upload-file-model';
@@ -14,7 +15,6 @@ import { BytesPipe } from "../../shared/pipes/bytes.pipe";
 import { ErrorService } from '../../shared/services/error.service';
 import { FileTypeService } from '../../shared/services/file-type.service';
 import { ModelLoadService } from '../../shared/services/model-load.service';
-import { AggregateError2 } from '../../shared/errors/aggregate.error';
 
 export type IOpenDialogData = {
   readonly titleText: string;
@@ -53,12 +53,14 @@ export class OpenDialogComponent implements OnInit {
 
   static open(
     dialog: MatDialog,
-    data: IOpenDialogData
+    injector: Injector,
+    data: IOpenDialogData,
   ) {
     return dialog.open<OpenDialogComponent, IOpenDialogData, BaseRenderModel<any>[]>(
       OpenDialogComponent,
       {
         data,
+        injector,
       }
     );
   }

--- a/src/app/dialogs/settings-dialog/settings-dialog.component.ts
+++ b/src/app/dialogs/settings-dialog/settings-dialog.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe, DOCUMENT } from '@angular/common';
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, Injector, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -34,8 +34,8 @@ export class SettingsDialogComponent implements OnInit {
     byteFormat: new FormControl(undefined as ByteFormatType | undefined, { validators: [Validators.required], nonNullable: true }),
   });
 
-  static open(dialog: MatDialog) {
-    return dialog.open(SettingsDialogComponent);
+  static open(dialog: MatDialog, injector: Injector) {
+    return dialog.open(SettingsDialogComponent, { injector });
   }
 
   ngOnInit(): void {

--- a/src/app/dialogs/zip-download-model-dialog/zip-download-model-dialog.component.ts
+++ b/src/app/dialogs/zip-download-model-dialog/zip-download-model-dialog.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe, NgIf } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, inject } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -59,12 +59,14 @@ export class ZipDownloadModelDialogComponent {
 
   static open(
     dialog: MatDialog,
+    injector: Injector,
     data: IZipDownloadModelDialogData,
   ) {
     return dialog.open<ZipDownloadModelDialogComponent, IZipDownloadModelDialogData, boolean>(
       ZipDownloadModelDialogComponent,
       {
         data,
+        injector,
       },
     );
   }

--- a/src/app/pages/main/main.component.html
+++ b/src/app/pages/main/main.component.html
@@ -1,0 +1,8 @@
+<div class="drop-overlay" data-draggable="main">
+  <div class="drop-overlay-inner" data-draggable="main">Drop files here</div>
+</div>
+
+<mapper-tools-bar />
+<mapper-compass />
+<mapper-canvas />
+<mapper-file-url-loader />

--- a/src/app/pages/main/main.component.scss
+++ b/src/app/pages/main/main.component.scss
@@ -1,0 +1,66 @@
+:host {
+  display: grid;
+  grid-template-areas: 'main';
+  overflow: hidden;
+
+  grid-area: app-main;
+  place-self: stretch stretch;
+
+  &>mapper-tools-bar {
+    grid-area: main;
+    justify-self: center;
+    align-self: end;
+    margin-bottom: 1em;
+    z-index: 2;
+  }
+
+  &>mapper-canvas {
+    grid-area: main;
+    justify-self: stretch;
+    align-self: stretch;
+    overflow: hidden;
+  }
+
+  &>mapper-compass {
+    grid-area: main;
+    justify-self: end;
+    align-self: end;
+    z-index: 1;
+  }
+
+  &>mapper-file-url-loader {
+    grid-area: main;
+    justify-self: center;
+    align-self: center;
+    z-index: 1;
+  }
+
+
+  .drop-overlay {
+    display: none;
+  }
+
+  &.file-is-dragging-over .drop-overlay {
+    display: grid;
+    align-items: stretch;
+    justify-items: stretch;
+
+    user-select: none;
+
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: 999;
+
+    background: rgba(255, 255, 255, 0.5);
+
+    .drop-overlay-inner {
+      display: grid;
+      align-items: center;
+      justify-content: center;
+      margin: 1em;
+      border: 1em dashed;
+      pointer-events: none;
+    }
+  }
+}

--- a/src/app/pages/main/main.component.spec.ts
+++ b/src/app/pages/main/main.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MainComponent } from './main.component';
+
+describe('MainComponent', () => {
+  let component: MainComponent;
+  let fixture: ComponentFixture<MainComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MainComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(MainComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/main/main.component.ts
+++ b/src/app/pages/main/main.component.ts
@@ -1,0 +1,98 @@
+import { ChangeDetectionStrategy, Component, HostBinding, HostListener, inject } from '@angular/core';
+import { ToolsBarComponent } from "../../shared/components/tools-bar/tools-bar.component";
+import { CompassComponent } from "../../shared/components/compass/compass.component";
+import { CanvasComponent } from "../canvas/canvas.component";
+import { FileUrlLoaderComponent } from "../file-url-loader/file-url-loader.component";
+import { DialogOpenerService } from '../../shared/services/dialog-opener.service';
+
+@Component({
+  selector: 'mapper-main',
+  standalone: true,
+  templateUrl: './main.component.html',
+  styleUrl: './main.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ToolsBarComponent, CompassComponent, CanvasComponent, FileUrlLoaderComponent]
+})
+export class MainComponent {
+
+  readonly #dialogOpener = inject(DialogOpenerService);
+
+  @HostBinding('attr.data-draggable')
+  readonly dataDraggable = 'main';
+
+  @HostBinding('class.file-is-dragging-over')
+  fileIsDraggingOver = false;
+
+  @HostListener('dragenter', ['$event'])
+  dragEnter(e: DragEvent) {
+    console.debug('dragenter', e);
+  }
+
+  /**
+   * @description
+   * when overlay first appears this triggers with:
+   *  current=mapper
+   *  target=canvas (or wherever the drag came from before the overlay)
+   *
+   * when the mouse leave the screen:
+   *  current=mapper
+   *  target=drop-overlay
+   *
+   * when the mouse leaves to another area:
+   *  current=mapper
+   *  target=drop-overlay
+   *
+   * when the overlay appears, this triggers, BUT it has a "relatedTarget".
+   * When the hover leaves the screen, "relatedTarget" is null.
+   *
+   * HOWEVER:
+   *  Safari never has a related target...
+   */
+  @HostListener('dragleave', ['$event'])
+  dragLeave(e: DragEvent) {
+    if (e.target instanceof HTMLElement) {
+      const targetDataset = e.target.dataset;
+      if (targetDataset['draggable'] === 'main') {
+        this.fileIsDraggingOver = false;
+      }
+    }
+    console.debug('dragleave', {
+      related: e.relatedTarget,
+      target: e.target,
+      current: e.currentTarget,
+      leaving: !this.fileIsDraggingOver,
+    });
+  }
+
+  @HostListener('dragover', ['$event'])
+  dragOver(e: DragEvent) {
+    if (!e.dataTransfer) {
+      return;
+    }
+    if (e.dataTransfer.types.includes('Files')) {
+      console.debug('dragOver with files');
+      e.preventDefault();
+      e.stopPropagation();
+      this.fileIsDraggingOver = true;
+    }
+    else {
+      console.debug('dragOver non-files:', ...e.dataTransfer.types);
+    }
+  }
+
+  @HostListener('drop', ['$event'])
+  drop(e: DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.fileIsDraggingOver = false;
+
+    const files = e.dataTransfer?.files;
+    if (!files?.length) {
+      return;
+    }
+
+    console.info('file drop', e, files);
+
+    this.#dialogOpener.import(files);
+  }
+}

--- a/src/app/pages/main/routes.ts
+++ b/src/app/pages/main/routes.ts
@@ -1,8 +1,0 @@
-import { Routes } from "@angular/router";
-
-const routes: Routes = [
-  {
-    path: '**',
-
-  }
-]

--- a/src/app/pages/main/routes.ts
+++ b/src/app/pages/main/routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from "@angular/router";
+
+const routes: Routes = [
+  {
+    path: '**',
+
+  }
+]

--- a/src/app/pages/right-tab-nav/cross-section-tab/cross-section-tab.component.ts
+++ b/src/app/pages/right-tab-nav/cross-section-tab/cross-section-tab.component.ts
@@ -16,6 +16,7 @@ import { CrossSectionAnnotation } from '../../../shared/models/annotations/cross
 import { ISimpleVector3, vector3FromSimpleVector3 } from '../../../shared/models/simple-types';
 import { ignoreNullish } from '../../../shared/operators/ignore-nullish';
 import { VectorPipe } from '../../../shared/pipes/vector.pipe';
+import { DialogOpenerService } from '../../../shared/services/dialog-opener.service';
 import { LocalizeService } from '../../../shared/services/localize.service';
 import { CrossSectionToolService } from '../../../shared/services/tools/cross-section-tool.service';
 
@@ -31,6 +32,7 @@ export class CrossSectionTabComponent {
   readonly #dialog = inject(MatDialog);
   readonly crossSectionTool = inject(CrossSectionToolService);
   readonly #localize = inject(LocalizeService);
+  readonly #dialogOpener = inject(DialogOpenerService);
 
   readonly dialogOpen$ = new BehaviorSubject(false);
 
@@ -176,15 +178,10 @@ export class CrossSectionTabComponent {
 
     this.dialogOpen$.next(true);
 
-    const { CrossSectionRenderDialogComponent } = await import('../../../dialogs/cross-section-render-dialog/cross-section-render-dialog.component');
-
-    CrossSectionRenderDialogComponent.open(
-      this.#dialog,
-      {
-        crossSection: selected,
-        formGroup: this.formGroup.controls.details,
-      },
-    ).afterClosed().subscribe(() => {
+    this.#dialogOpener.exportCrossSection({
+      crossSection: selected,
+      formGroup: this.formGroup.controls.details,
+    }).subscribe(() => {
       this.dialogOpen$.next(false);
     });
   }

--- a/src/app/shared/services/dialog-opener.service.ts
+++ b/src/app/shared/services/dialog-opener.service.ts
@@ -1,6 +1,8 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ModelManagerService } from './model-manager.service';
+import { ICrossSectionRenderDialogData } from '../../dialogs/cross-section-render-dialog/cross-section-render-dialog.component';
+import { defer, switchMap } from 'rxjs';
 
 /**
  * Service solely responsible for opening dialogs
@@ -10,11 +12,12 @@ export class DialogOpenerService {
 
   readonly #modelManager = inject(ModelManagerService);
   readonly #dialog = inject(MatDialog);
+  readonly #injector = inject(Injector);
 
   open() {
     import('../../dialogs/open-dialog/open-dialog.component')
       .then(({ OpenDialogComponent }) => {
-        OpenDialogComponent.open(this.#dialog, {
+        OpenDialogComponent.open(this.#dialog, this.#injector, {
           submitText: 'Open',
           titleText: 'Open a file',
           multiple: false,
@@ -24,13 +27,20 @@ export class DialogOpenerService {
           }
         });
       });
+  }
 
+  exportCrossSection(data: ICrossSectionRenderDialogData) {
+    return defer(() => import('../../dialogs/cross-section-render-dialog/cross-section-render-dialog.component')).pipe(
+      switchMap(({ CrossSectionRenderDialogComponent }) => {
+        return CrossSectionRenderDialogComponent.open(this.#dialog, this.#injector, data).afterClosed();
+      })
+    )
   }
 
   import(initialFiles?: FileList) {
     import('../../dialogs/open-dialog/open-dialog.component')
       .then(({ OpenDialogComponent }) => {
-        OpenDialogComponent.open(this.#dialog, {
+        OpenDialogComponent.open(this.#dialog, this.#injector, {
           submitText: 'Import',
           titleText: 'Import one or more files',
           multiple: true,
@@ -46,7 +56,7 @@ export class DialogOpenerService {
   save() {
     import('../../dialogs/zip-download-model-dialog/zip-download-model-dialog.component')
       .then(({ ZipDownloadModelDialogComponent }) => {
-        ZipDownloadModelDialogComponent.open(this.#dialog, {
+        ZipDownloadModelDialogComponent.open(this.#dialog, this.#injector, {
           titleText: 'Zip and download group',
         });
       });
@@ -55,7 +65,7 @@ export class DialogOpenerService {
   settings() {
     import('../../dialogs/settings-dialog/settings-dialog.component')
       .then(({ SettingsDialogComponent }) => {
-        SettingsDialogComponent.open(this.#dialog);
+        SettingsDialogComponent.open(this.#dialog, this.#injector);
       });
   }
 
@@ -64,6 +74,7 @@ export class DialogOpenerService {
       .then(({ ExportImageDialogComponent }) => {
         ExportImageDialogComponent.open(
           this.#dialog,
+          this.#injector,
           {
             titleText: 'Export image',
           },


### PR DESCRIPTION
Version: 0.2.0

Goals
- [x] minimize initial load size with "app shell" pattern, only loading the minimum for a recognizable layout

Features:
* 3 router-outlets: `main`, `left-side-nav`, and `right-tab-nav`
* `deferred.routes` loads MainComponent, SidenavComponent and RightTabNavComponent into corresponding outlets
* file drop logic moved into `main.component`, but drops not caught by main are still caught and ignored by `app.component`
* ALMOST all providers are moved into `deferred.routes`, but some core things are left at the top
* dialogs now need injector passed in, as not all providers are at the global level... interesting change
   - _I think all dialog openers need a service declared in the deferred routes but I'l come back to that_
* build/cache optimizations
   - significantly reduce max initial bundle to 1mb
   - (try to) cache google fonts
   - don't cache `/assets/files`




TODO:
 - [ ] clicking a sidenav button closes the sidenav

