### PR TITLE
Cavern seer scan work

### DIFF
--- a/.run/start.run.xml
+++ b/.run/start.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="start" type="js.build_tools.npm" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="start" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavern-seer-mapper",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.2.1",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavern-seer-mapper",
-      "version": "0.2.1",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.0.0",
@@ -23,6 +23,7 @@
         "@angular/service-worker": "^17.0.0",
         "@angular/ssr": "^17.0.0",
         "@ngrx/store": "^17.0.1",
+        "@skgrush/bplist-and-nskeyedunarchiver": "file:../bplist-and-nskeyedunarchiver/dist/skgrush-bplist-and-nskeyedunarchiver-0.0.1-rc.0.tgz",
         "express": "^4.18.2",
         "jszip": "^3.10.1",
         "rxjs": "~7.8.0",
@@ -4473,6 +4474,12 @@
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
+    },
+    "node_modules/@skgrush/bplist-and-nskeyedunarchiver": {
+      "version": "0.0.1-rc.0",
+      "resolved": "file:../bplist-and-nskeyedunarchiver/dist/skgrush-bplist-and-nskeyedunarchiver-0.0.1-rc.0.tgz",
+      "integrity": "sha512-y167qUPTELyWrs8EZ56CYA1MsdyjMRHPBv2lACIy5sVkymGvCBoL9K+eGKiYQjXVFP/3xilxvVLafI5v5koGrA==",
+      "license": "MIT"
     },
     "node_modules/@skgrush/sync-s3": {
       "version": "0.0.1-rc.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@angular/service-worker": "^17.0.0",
         "@angular/ssr": "^17.0.0",
         "@ngrx/store": "^17.0.1",
-        "@skgrush/bplist-and-nskeyedunarchiver": "file:../bplist-and-nskeyedunarchiver/dist/skgrush-bplist-and-nskeyedunarchiver-0.0.1-rc.0.tgz",
+        "@skgrush/bplist-and-nskeyedunarchiver": "0.0.1-rc.1",
         "express": "^4.18.2",
         "jszip": "^3.10.1",
         "rxjs": "~7.8.0",
@@ -4476,10 +4476,9 @@
       }
     },
     "node_modules/@skgrush/bplist-and-nskeyedunarchiver": {
-      "version": "0.0.1-rc.0",
-      "resolved": "file:../bplist-and-nskeyedunarchiver/dist/skgrush-bplist-and-nskeyedunarchiver-0.0.1-rc.0.tgz",
-      "integrity": "sha512-y167qUPTELyWrs8EZ56CYA1MsdyjMRHPBv2lACIy5sVkymGvCBoL9K+eGKiYQjXVFP/3xilxvVLafI5v5koGrA==",
-      "license": "MIT"
+      "version": "0.0.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@skgrush/bplist-and-nskeyedunarchiver/-/bplist-and-nskeyedunarchiver-0.0.1-rc.1.tgz",
+      "integrity": "sha512-BW61wqzVt1WdO0ofQTWY8h5j/jRYUduhJiXKmtQQSMFF+sTwt5dfyXfelr1R2fdhXjs4m3/b6KTrAzPyJ517dA=="
     },
     "node_modules/@skgrush/sync-s3": {
       "version": "0.0.1-rc.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@angular/service-worker": "^17.0.0",
     "@angular/ssr": "^17.0.0",
     "@ngrx/store": "^17.0.1",
+    "@skgrush/bplist-and-nskeyedunarchiver": "file:../bplist-and-nskeyedunarchiver/dist/skgrush-bplist-and-nskeyedunarchiver-0.0.1-rc.0.tgz",
     "express": "^4.18.2",
     "jszip": "^3.10.1",
     "rxjs": "~7.8.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@angular/service-worker": "^17.0.0",
     "@angular/ssr": "^17.0.0",
     "@ngrx/store": "^17.0.1",
-    "@skgrush/bplist-and-nskeyedunarchiver": "file:../bplist-and-nskeyedunarchiver/dist/skgrush-bplist-and-nskeyedunarchiver-0.0.1-rc.0.tgz",
+    "@skgrush/bplist-and-nskeyedunarchiver": "0.0.1-rc.1",
     "express": "^4.18.2",
     "jszip": "^3.10.1",
     "rxjs": "~7.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "homepage": "https://github.com/skgrush/cavern-seer-mapper#readme",
   "license": "MIT",
   "author": {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -13,12 +13,14 @@ import { INTL_LOCALE } from './shared/tokens/intl-locale.token';
 import { INTL_UNIT_LIST_FORMAT } from './shared/tokens/intl-unit-list-format.token';
 import { LOCAL_STORAGE } from './shared/tokens/local-storage.token';
 import { MAPPER_VERSION, VersionObject } from './shared/tokens/version.token';
+import { provideHttpClient } from '@angular/common/http';
 
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
     provideAnimations(),
+    provideHttpClient(),
     ErrorService,
     AlertService,
     importProvidersFrom(MatSnackBarModule),

--- a/src/app/shared/components/cross-section-details-form/cross-section-details-form.component.html
+++ b/src/app/shared/components/cross-section-details-form/cross-section-details-form.component.html
@@ -8,15 +8,15 @@
     </div>
     <mat-form-field>
       <mat-label>X</mat-label>
-      <input matInput type="number" [formControl]="formGroup.controls.position.controls.x">
+      <input matInput type="number" step="0.1" [formControl]="formGroup.controls.position.controls.x">
     </mat-form-field>
     <mat-form-field>
       <mat-label>Y</mat-label>
-      <input matInput type="number" [formControl]="formGroup.controls.position.controls.y">
+      <input matInput type="number" step="0.1" [formControl]="formGroup.controls.position.controls.y">
     </mat-form-field>
     <mat-form-field>
       <mat-label>Z</mat-label>
-      <input matInput type="number" [formControl]="formGroup.controls.position.controls.z">
+      <input matInput type="number" step="0.1" [formControl]="formGroup.controls.position.controls.z">
     </mat-form-field>
   </section>
   <section class="label-and-form-trio">
@@ -24,15 +24,15 @@
     <div></div>
     <mat-form-field>
       <mat-label>Width</mat-label>
-      <input matInput type="number" [formControl]="formGroup.controls.dimensions.controls.x">
+      <input matInput type="number" step="0.1" [formControl]="formGroup.controls.dimensions.controls.x">
     </mat-form-field>
     <mat-form-field>
       <mat-label>Height</mat-label>
-      <input matInput type="number" [formControl]="formGroup.controls.dimensions.controls.y">
+      <input matInput type="number" step="0.1" [formControl]="formGroup.controls.dimensions.controls.y">
     </mat-form-field>
     <mat-form-field>
       <mat-label>Depth</mat-label>
-      <input matInput type="number" [formControl]="formGroup.controls.dimensions.controls.z">
+      <input matInput type="number" step="0.1" [formControl]="formGroup.controls.dimensions.controls.z">
     </mat-form-field>
   </section>
   <mat-form-field>

--- a/src/app/shared/components/file-icon/file-icon.component.ts
+++ b/src/app/shared/components/file-icon/file-icon.component.ts
@@ -21,6 +21,7 @@ export class FileIconComponent {
     group: 'folder_zip',
     gltf: 'svg:glTF_White',
     obj: 'shape_line',
+    cavernseerscan: 'svg:CavernSeer',
   } satisfies Record<FileModelType, string>);
 
 

--- a/src/app/shared/components/file-icon/file-icon.module.ts
+++ b/src/app/shared/components/file-icon/file-icon.module.ts
@@ -19,5 +19,10 @@ export class FileIconModule {
       'glTF_White',
       sanitizer.bypassSecurityTrustResourceUrl('/assets/icons/svg/glTF_White_June16.svg'),
     );
+    registry.addSvgIconInNamespace(
+      'svg',
+      'CavernSeer',
+      sanitizer.bypassSecurityTrustResourceUrl('/assets/icons/fav/iconflat.svg'),
+    );
   }
 }

--- a/src/app/shared/components/model-detail-form/model-detail-form.component.html
+++ b/src/app/shared/components/model-detail-form/model-detail-form.component.html
@@ -1,16 +1,16 @@
 <form *ngIf="model.rendered">
   <mat-form-field>
     <mat-label>X</mat-label>
-    <input matInput type="number" [formControl]="formGroup.controls.position.controls.x">
+    <input matInput type="number" step="0.1" [formControl]="formGroup.controls.position.controls.x">
   </mat-form-field>
 
   <mat-form-field>
     <mat-label>Y</mat-label>
-    <input matInput type="number" [formControl]="formGroup.controls.position.controls.y">
+    <input matInput type="number" step="0.1" [formControl]="formGroup.controls.position.controls.y">
   </mat-form-field>
 
   <mat-form-field>
     <mat-label>Z</mat-label>
-    <input matInput type="number" [formControl]="formGroup.controls.position.controls.z">
+    <input matInput type="number" step="0.1" [formControl]="formGroup.controls.position.controls.z">
   </mat-form-field>
 </form>

--- a/src/app/shared/functions/float4x4-to-matrix4.ts
+++ b/src/app/shared/functions/float4x4-to-matrix4.ts
@@ -1,0 +1,14 @@
+import type { Float4x4 } from "@skgrush/bplist-and-nskeyedunarchiver/NSKeyedUnarchiver";
+import { Matrix4 } from "three";
+
+/**
+ * Three.js's {@link Matrix4} is stored in a transposed form from our normal matrices.
+ * This converts from Float4x4 to Matrix4.
+ */
+export function float4x4ToMatrix4(float4x4: Float4x4) {
+  const float4x4Elements = float4x4.flat() as [number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number];
+  if (float4x4Elements.length !== 16) {
+    throw new Error('float4x4 did not contain 16 elements');
+  }
+  return new Matrix4(...float4x4Elements).transpose();
+}

--- a/src/app/shared/models/model-manifest.ts
+++ b/src/app/shared/models/model-manifest.ts
@@ -1,6 +1,7 @@
 import { ignoreNullishArray } from "../operators/ignore-nullish";
 import { AnnotationBuilderService } from "../services/annotation-builder.service";
 import { BaseAnnotation } from "./annotations/base.annotation";
+import { TemporaryAnnotation } from "./annotations/temporary.annotation";
 import { IMetadataBaseAnnotationV0, IMetadataEntryV0 } from "./manifest/types.v0";
 import { BaseRenderModel, BaseVisibleRenderModel } from "./render/base.render-model";
 import { GroupRenderModel } from "./render/group.render-model";
@@ -97,6 +98,7 @@ export class ModelManifestV0 extends BaseModelManifest {
   static #buildAnnotations(model: BaseRenderModel<any>): IMetadataBaseAnnotationV0[] | null {
     if (model instanceof BaseVisibleRenderModel) {
       const serializedAnnos = model.getAnnotations()
+        .filter(anno => !(anno instanceof TemporaryAnnotation))
         .map(anno => anno.serializeToManifest(0))
         .filter(ignoreNullishArray);
 

--- a/src/app/shared/models/model-type.enum.ts
+++ b/src/app/shared/models/model-type.enum.ts
@@ -6,4 +6,6 @@ export enum FileModelType {
   obj = 'obj',
   /** gLTF or GLB file */
   gLTF = 'gltf',
+  /** CavernSeer ScanFile binary */
+  cavernseerscan = 'cavernseerscan',
 }

--- a/src/app/shared/models/render/any-render-model.ts
+++ b/src/app/shared/models/render/any-render-model.ts
@@ -1,3 +1,4 @@
+import { CavernSeerScanRenderModel } from "./cavern-seer-scan.render-model";
 import type { GltfRenderModel } from "./gltf.render-model";
 import type { GroupRenderModel } from "./group.render-model";
 import type { ObjRenderModel } from "./obj.render-model";
@@ -7,4 +8,5 @@ export type AnyRenderModel =
   | GltfRenderModel
   | GroupRenderModel
   | ObjRenderModel
+  | CavernSeerScanRenderModel
   | UnknownRenderModel;

--- a/src/app/shared/models/render/cavern-seer-scan.render-model.ts
+++ b/src/app/shared/models/render/cavern-seer-scan.render-model.ts
@@ -1,0 +1,129 @@
+import { Subject } from "rxjs";
+import { FileModelType } from "../model-type.enum";
+import { BaseVisibleRenderModel } from "./base.render-model";
+import { Group, Mesh, Object3DEventMap, Vector3 } from "three";
+import type { CSMeshSnapshot, SurveyLine, SurveyStation } from "../../types/cavern-seer-scan";
+import { UploadFileModel } from "../upload-file-model";
+import { ISimpleVector3 } from "../simple-types";
+import { BaseMaterialService } from "../../services/3d-managers/base-material.service";
+import { BaseAnnotation } from "../annotations/base.annotation";
+import { ModelChangeType } from "../model-change-type.enum";
+import { IMapperUserData } from "../user-data";
+
+export interface IScanFileParsed {
+  readonly encodingVersion: bigint;
+  readonly timestamp: Date;
+  readonly name: string;
+  readonly group: Group;
+  readonly startSnapshot: CSMeshSnapshot | null;
+  readonly endSnapshot: CSMeshSnapshot | null;
+  readonly stations: SurveyStation[];
+  readonly lines: SurveyLine[];
+}
+
+export class CavernSeerScanRenderModel extends BaseVisibleRenderModel<FileModelType.cavernseerscan> {
+  override readonly type = FileModelType.cavernseerscan;
+  override readonly #childOrPropertyChanged = new Subject<ModelChangeType>();
+  override readonly childOrPropertyChanged$ = this.#childOrPropertyChanged.asObservable();
+  override readonly position: Readonly<Vector3> = new Vector3();
+  override readonly identifier: string;
+  override comment: string | null;
+  override readonly rendered = true;
+
+  readonly #blob: Blob;
+  readonly #parsedScanFile: IScanFileParsed;
+  readonly #group: Group;
+  readonly #annotations = new Set<BaseAnnotation>();
+
+  constructor(
+    identifier: string,
+    parsedScanFile: IScanFileParsed,
+    blob: Blob,
+    comment: string | null,
+  ) {
+    super();
+
+    this.identifier = identifier;
+    this.comment = comment;
+    this.#blob = blob;
+
+    this.#parsedScanFile = parsedScanFile;
+    this.#group = parsedScanFile.group;
+
+    debugger;
+  }
+
+  static fromUploadModelAndParsedScanFile(uploadModel: UploadFileModel, parsedScan: IScanFileParsed) {
+    const { identifier, blob, comment } = uploadModel;
+    return new CavernSeerScanRenderModel(
+      identifier,
+      parsedScan,
+      blob,
+      comment,
+    );
+  }
+
+  override setComment(comment: string | null): boolean {
+    this.comment = comment;
+    return true;
+  }
+  override serialize(): Blob | null {
+    return this.#blob;
+  }
+  override setPosition({ x, y, z }: ISimpleVector3): boolean {
+    this.#group.position.set(x, y, z);
+    this.#childOrPropertyChanged.next(ModelChangeType.PositionChanged);
+    return true;
+
+  }
+  override setMaterial(material: BaseMaterialService<any>): void {
+    this.#group.traverse(child => {
+      if (child instanceof Mesh && (child.userData as IMapperUserData).fromSerializedModel) {
+        child.material = material.material;
+      }
+    });
+  }
+  override addToGroup(group: Group<Object3DEventMap>): void {
+    if (this.#group.parent !== null) {
+      throw new Error('attempt to add CavernSeerScanRenderModel to group while model already has a parent');
+    }
+    group.add(this.#group);
+  }
+  override removeFromGroup(group: Group<Object3DEventMap>): void {
+    group.remove(this.#group);
+  }
+  override dispose(): void {
+    // throw new Error("Method not implemented.");
+  }
+  override getAnnotations(): readonly BaseAnnotation[] {
+    return [...this.#annotations];
+  }
+
+  override addAnnotation(anno: BaseAnnotation, toGroup?: Group<Object3DEventMap> | undefined): boolean {
+    if (toGroup && this.#group !== toGroup) {
+      return false;
+    }
+
+    anno.addToGroup(this.#group);
+    this.#annotations.add(anno);
+    this.#childOrPropertyChanged.next(ModelChangeType.EntityAdded);
+    return true;
+  }
+
+  override removeAnnotations(annosToDelete: Set<BaseAnnotation>): void {
+    for (const anno of annosToDelete) {
+
+      const deleted = this.#annotations.delete(anno);
+      if (!deleted) {
+        continue;
+      }
+
+      anno.removeFromGroup(this.#group);
+      this.#childOrPropertyChanged.next(ModelChangeType.EntityRemoved);
+
+      annosToDelete.delete(anno);
+    }
+  }
+
+
+}

--- a/src/app/shared/models/render/cavern-seer-scan.render-model.ts
+++ b/src/app/shared/models/render/cavern-seer-scan.render-model.ts
@@ -51,6 +51,11 @@ export class CavernSeerScanRenderModel extends BaseVisibleRenderModel<FileModelT
     this.#group = parsedScanFile.group;
 
     debugger;
+
+    (this.#group.userData as IMapperUserData).fromSerializedModel = true;
+    this.#group.traverse(child => {
+      (child.userData as IMapperUserData).fromSerializedModel = true;
+    })
   }
 
   static fromUploadModelAndParsedScanFile(uploadModel: UploadFileModel, parsedScan: IScanFileParsed) {

--- a/src/app/shared/models/render/cavern-seer-scan.render-model.ts
+++ b/src/app/shared/models/render/cavern-seer-scan.render-model.ts
@@ -58,8 +58,6 @@ export class CavernSeerScanRenderModel extends BaseVisibleRenderModel<FileModelT
     this.#parsedScanFile = parsedScanFile;
     this.#group = parsedScanFile.group;
 
-    debugger;
-
     (this.#group.userData as IMapperUserData).fromSerializedModel = true;
     this.#group.traverse(child => {
       (child.userData as IMapperUserData).fromSerializedModel = true;
@@ -287,8 +285,6 @@ export class CavernSeerScanRenderModel extends BaseVisibleRenderModel<FileModelT
       console.warn('File format is not JPEG; ignoring');
       return;
     }
-
-    debugger;
 
     let byteOffset = 2;
 

--- a/src/app/shared/models/render/gltf.render-model.ts
+++ b/src/app/shared/models/render/gltf.render-model.ts
@@ -2,12 +2,13 @@ import { GLTF } from "three/examples/jsm/loaders/GLTFLoader";
 import { BaseVisibleRenderModel } from "./base.render-model";
 import { FileModelType } from "../model-type.enum";
 import { BaseMaterialService } from "../../services/3d-managers/base-material.service";
-import { Group, Object3DEventMap, Vector3 } from "three";
+import { BoxHelper, Camera, Group, Mesh, Object3DEventMap, Vector3 } from "three";
 import { Subject } from "rxjs";
 import { ISimpleVector3 } from "../simple-types";
 import { UploadFileModel } from "../upload-file-model";
 import { BaseAnnotation } from "../annotations/base.annotation";
 import { ModelChangeType } from "../model-change-type.enum";
+import { IMapperUserData } from "../user-data";
 
 /**
  * TODO: #11: https://github.com/skgrush/cavern-seer-mapper/issues/11
@@ -20,24 +21,41 @@ export class GltfRenderModel extends BaseVisibleRenderModel<FileModelType.gLTF> 
   override readonly identifier: string;
   override comment: string | null;
   override readonly rendered = true;
+
   override get position(): Readonly<Vector3> {
-    throw new Error('position not implemented in GltfModel');
+    return this.#gltf.scene.position;
   }
 
   readonly #blob: Blob;
-  readonly #object: GLTF;
+  readonly #gltf: GLTF;
+
+  readonly #boxHelper: BoxHelper;
+  readonly #annotations = new Set<BaseAnnotation>();
 
   constructor(
     identifier: string,
     blob: Blob,
-    object: GLTF,
+    gltf: GLTF,
     comment: string | null,
   ) {
     super();
     this.identifier = identifier;
     this.#blob = blob;
-    this.#object = object;
+    this.#gltf = gltf;
     this.comment = comment;
+
+    debugger;
+
+    const object = gltf.scene;
+    this.#boxHelper = new BoxHelper(object);
+    (object.userData as IMapperUserData).fromSerializedModel = true;
+    object.traverse(child => {
+      if (child instanceof Camera) {
+        console.warn('Found camera in GLTF', identifier, '; unsupported behavior.');
+      }
+
+      (child.userData as IMapperUserData).fromSerializedModel = true;
+    })
   }
 
   static fromUploadModel(uploadModel: UploadFileModel, object: GLTF) {
@@ -59,28 +77,61 @@ export class GltfRenderModel extends BaseVisibleRenderModel<FileModelType.gLTF> 
     return true;
   }
 
-  override setPosition(pos: ISimpleVector3): boolean {
-    throw new Error("Method not implemented in GltfModel.");
+  override setPosition({ x, y, z }: ISimpleVector3): boolean {
+    this.#gltf.scene.position.set(x, y, z);
+    this.#childOrPropertyChanged.next(ModelChangeType.PositionChanged);
+    return true;
   }
+
   override setMaterial(material: BaseMaterialService<any>): void {
-    throw new Error("Method not implemented in GltfModel.");
+    this.#gltf.scene.traverse(child => {
+      if (child instanceof Mesh && (child.userData as IMapperUserData).fromSerializedModel) {
+        child.material = material.material;
+      }
+    });
   }
+
   override addToGroup(group: Group<Object3DEventMap>): void {
-    throw new Error("Method not implemented.");
+    if (this.#gltf.scene.parent !== null) {
+      throw new Error('attempt to add GltfRenderModel to group while model already has a parent');
+    }
+    group.add(this.#gltf.scene);
   }
+
   override removeFromGroup(group: Group<Object3DEventMap>): void {
-    throw new Error("Method not implemented.");
+    group.remove(this.#gltf.scene);
   }
+
   override dispose(): void {
-    throw new Error("Method not implemented.");
+    this.#boxHelper.dispose();
   }
+
   override getAnnotations(): readonly BaseAnnotation[] {
-    throw new Error("Method not implemented");
+    return [...this.#annotations];
   }
+
   override addAnnotation(anno: BaseAnnotation, toGroup?: Group): boolean {
-    throw new Error("Method not implemented");
+    if (toGroup && this.#gltf.scene !== toGroup) {
+      return false;
+    }
+
+    anno.addToGroup(this.#gltf.scene);
+    this.#annotations.add(anno);
+    this.#childOrPropertyChanged.next(ModelChangeType.EntityAdded);
+    return true;
   }
+
   override removeAnnotations(annosToDelete: Set<BaseAnnotation>): void {
-    throw new Error("Method not implemented");
+    for (const anno of annosToDelete) {
+      const deleted = this.#annotations.delete(anno);
+      if (!deleted) {
+        continue;
+      }
+
+      anno.removeFromGroup(this.#gltf.scene);
+      this.#childOrPropertyChanged.next(ModelChangeType.EntityRemoved);
+
+      annosToDelete.delete(anno);
+    }
   }
 }

--- a/src/app/shared/models/render/gltf.render-model.ts
+++ b/src/app/shared/models/render/gltf.render-model.ts
@@ -44,8 +44,6 @@ export class GltfRenderModel extends BaseVisibleRenderModel<FileModelType.gLTF> 
     this.#gltf = gltf;
     this.comment = comment;
 
-    debugger;
-
     const object = gltf.scene;
     this.#boxHelper = new BoxHelper(object);
     (object.userData as IMapperUserData).fromSerializedModel = true;

--- a/src/app/shared/models/render/obj.render-model.ts
+++ b/src/app/shared/models/render/obj.render-model.ts
@@ -39,7 +39,7 @@ export class ObjRenderModel extends BaseVisibleRenderModel<FileModelType.obj> {
     this.identifier = identifier;
     this.comment = comment;
 
-    (this.#object.userData as IMapperUserData).fromSerializedModel = true;
+    (object.userData as IMapperUserData).fromSerializedModel = true;
     object.traverse(child => {
       (child.userData as IMapperUserData).fromSerializedModel = true;
     })

--- a/src/app/shared/services/3d-managers/base-material.service.ts
+++ b/src/app/shared/services/3d-managers/base-material.service.ts
@@ -1,10 +1,7 @@
 import { DoubleSide, FrontSide, Material, Side } from 'three';
 
-export class BaseMaterialService<T extends Material> {
-
-  protected constructor(
-    public readonly material: T
-  ) { }
+export abstract class BaseMaterialService<T extends Material> {
+  abstract readonly material: T;
 
   setSide(side: Side) {
     this.material.side = side;

--- a/src/app/shared/services/3d-managers/mesh-normal-material.service.ts
+++ b/src/app/shared/services/3d-managers/mesh-normal-material.service.ts
@@ -4,8 +4,11 @@ import { BaseMaterialService } from './base-material.service';
 
 @Injectable()
 export class MeshNormalMaterialService extends BaseMaterialService<MeshNormalMaterial> {
+  override material: MeshNormalMaterial;
+
 
   constructor() {
-    super(new MeshNormalMaterial());
+    super();
+    this.material = new MeshNormalMaterial();
   }
 }

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, Observable, Subject, animationFrames, defer, distinctUntilChanged, filter, fromEvent, map, scan, switchMap, takeUntil, tap } from 'rxjs';
-import { AmbientLight, Box3, Camera, Clock, FrontSide, GridHelper, Material, OrthographicCamera, Raycaster, Scene, Side, Vector2, Vector3, WebGLRenderer } from 'three';
+import { AmbientLight, Box3, Camera, Clock, FrontSide, GridHelper, Material, OrthographicCamera, Raycaster, SRGBColorSpace, Scene, Side, Vector2, Vector3, WebGLRenderer } from 'three';
 import { markSceneOfItemForReRender } from '../functions/mark-scene-of-item-for-rerender';
 import { traverseSome } from '../functions/traverse-some';
 import { ModelChangeType } from '../models/model-change-type.enum';
@@ -427,6 +427,7 @@ export class CanvasService {
     });
     this.#rendererMap.set(this.#mainRendererSymbol, new WeakRef(this.#mainRenderer));
     this.#mainRenderer.autoClear = false;
+    this.#mainRenderer.outputColorSpace = SRGBColorSpace;
 
     const cam = new OrthographicCamera();
     this.#scene.add(cam);
@@ -435,7 +436,7 @@ export class CanvasService {
 
     // #TODO: #10: https://github.com/skgrush/cavern-seer-mapper/issues/10
     // // setting pixel ratio screws with raycasting??
-    // this.#renderer.setPixelRatio(pixelRatio);
+    // this.#mainRenderer.setPixelRatio(pixelRatio);
 
     this.#scene.add(new AmbientLight(0xFF2222, 2));
 

--- a/src/app/shared/services/cavern-seer-opener.service.spec.ts
+++ b/src/app/shared/services/cavern-seer-opener.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CavernSeerOpenerService } from './cavern-seer-opener.service';
+
+describe('CavernSeerOpenerService', () => {
+  let service: CavernSeerOpenerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CavernSeerOpenerService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/cavern-seer-opener.service.ts
+++ b/src/app/shared/services/cavern-seer-opener.service.ts
@@ -137,9 +137,6 @@ export class CavernSeerOpenerService {
     if (!result || typeof result !== 'object' || !('$archiver' in result)) {
       throw new Error('Invalid cavernseerscan file');
     }
-    // if (result['encodingVersion'] !== 2) {
-    //   throw new Error(`Expected cavernseerscan file encodingVersion 2 but got ${result['encodingVersion']}`);
-    // }
 
     return result as IArchivedPList;
   }

--- a/src/app/shared/services/cavern-seer-opener.service.ts
+++ b/src/app/shared/services/cavern-seer-opener.service.ts
@@ -6,6 +6,7 @@ import { KeyedUnarchiver, NSDateCoder, NSArrayCoder, NSUUIDCoder, Float4, Float4
 import type { TransportProgressHandler } from '../models/transport-progress-handler';
 import type { CSMeshGeometryElement, CSMeshGeometrySource, CSMeshSlice, CSMeshSnapshot, ScanFile, SurveyLine, SurveyStation } from '../types/cavern-seer-scan';
 import { BufferAttribute, BufferGeometry, Group, Material, Matrix4, Mesh, MeshBasicMaterial, Vector3 } from 'three';
+import { float4x4ToMatrix4 } from '../functions/float4x4-to-matrix4';
 
 export enum MTLVertexFormat {
   float3 = 30,
@@ -45,9 +46,7 @@ export class CavernSeerOpenerService {
     const mesh = new Mesh(geometry, mat);
     mesh.userData['cs:slice'] = true;
     mesh.name = slice.identifier.toString();
-    // convert normal float4x4 to Matrix4
-    const transform = new Matrix4(...slice.transform.flat() as [number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number])
-      .transpose();
+    const transform = float4x4ToMatrix4(slice.transform);
     mesh.matrix.copy(transform);
     mesh.matrixAutoUpdate = false;
     mesh.matrixWorldNeedsUpdate = true;

--- a/src/app/shared/services/cavern-seer-opener.service.ts
+++ b/src/app/shared/services/cavern-seer-opener.service.ts
@@ -27,6 +27,11 @@ export class CavernSeerOpenerService {
 
     const meshAnchors = scanFile.meshAnchors.map(slice => this.#meshSliceToGroup(slice, material));
 
+    if (!meshAnchors.length) {
+      debugger;
+      console.warn('ScanFile', scanFile.name, ' contains no meshes; this is probably from a corrupted scan');
+    }
+
     const group = new Group();
     group.add(...meshAnchors);
     group.name = scanFile.name;

--- a/src/app/shared/services/cavern-seer-opener.service.ts
+++ b/src/app/shared/services/cavern-seer-opener.service.ts
@@ -28,8 +28,9 @@ export class CavernSeerOpenerService {
 
     const group = new Group();
     group.children = meshAnchors;
-    group.userData['cs:encodingVersion'] = scanFile.name;
-    group.userData['encodingVersion'] = scanFile.encodingVersion;
+    group.name = scanFile.name;
+    group.userData['cs:timestamp'] = scanFile.timestamp;
+    group.userData['cs:encodingVersion'] = scanFile.encodingVersion;
 
     return group;
   }

--- a/src/app/shared/services/cavern-seer-opener.service.ts
+++ b/src/app/shared/services/cavern-seer-opener.service.ts
@@ -280,8 +280,8 @@ class SurveyLineCoder extends KeyedUnarchiver<SurveyLine> {
 
   decode(): SurveyLine {
     return {
-      startIdentifier: this.decodeObjectOf(NSUUIDCoder, 'startId', true),
-      endIdentifier: this.decodeObjectOf(NSUUIDCoder, 'endId', true),
+      startIdentifier: this.decodeObjectOf(NSUUIDCoder, 'startIdentifier', true),
+      endIdentifier: this.decodeObjectOf(NSUUIDCoder, 'endIdentifier', true),
     }
   }
 }
@@ -297,7 +297,7 @@ class SurveyStationCoder extends KeyedUnarchiver<SurveyStation> {
   }
 
   static initForReadingDataFrom($objects: $ObjectsMap, data: IArchivedInstance) {
-    return new SurveyLineCoder($objects, data);
+    return new SurveyStationCoder($objects, data);
   }
 
   decode(): SurveyStation {

--- a/src/app/shared/services/cavern-seer-opener.service.ts
+++ b/src/app/shared/services/cavern-seer-opener.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@angular/core';
 
+import { $ObjectsMap, Float4, Float4x4, IArchivedInstance, IArchivedPList, KeyedUnarchiver, NSArrayCoder, NSDateCoder, NSUUIDCoder } from '@skgrush/bplist-and-nskeyedunarchiver/NSKeyedUnarchiver';
 import { Reader, deStructWithIter } from '@skgrush/bplist-and-nskeyedunarchiver/bplist';
-import { UploadFileModel } from '../models/upload-file-model';
-import { KeyedUnarchiver, NSDateCoder, NSArrayCoder, NSUUIDCoder, Float4, Float4x4, $ObjectsMap, IArchivedInstance, IArchivedPList } from '@skgrush/bplist-and-nskeyedunarchiver/NSKeyedUnarchiver';
-import type { TransportProgressHandler } from '../models/transport-progress-handler';
-import type { CSMeshGeometryElement, CSMeshGeometrySource, CSMeshSlice, CSMeshSnapshot, ScanFile, SurveyLine, SurveyStation } from '../types/cavern-seer-scan';
-import { BufferAttribute, BufferGeometry, Group, Material, Matrix4, Mesh, MeshBasicMaterial, Vector3 } from 'three';
+import { BufferAttribute, BufferGeometry, Group, Material, Mesh, MeshBasicMaterial } from 'three';
 import { float4x4ToMatrix4 } from '../functions/float4x4-to-matrix4';
+import type { TransportProgressHandler } from '../models/transport-progress-handler';
+import { UploadFileModel } from '../models/upload-file-model';
+import type { CSMeshGeometryElement, CSMeshGeometrySource, CSMeshSlice, CSMeshSnapshot, ScanFile, SurveyLine, SurveyStation } from '../types/cavern-seer-scan';
 
 export enum MTLVertexFormat {
   float3 = 30,
@@ -28,10 +28,11 @@ export class CavernSeerOpenerService {
     const meshAnchors = scanFile.meshAnchors.map(slice => this.#meshSliceToGroup(slice, material));
 
     const group = new Group();
-    group.children = meshAnchors;
+    group.add(...meshAnchors);
     group.name = scanFile.name;
     group.userData['cs:timestamp'] = scanFile.timestamp;
     group.userData['cs:encodingVersion'] = scanFile.encodingVersion;
+    group.matrixWorldNeedsUpdate = true;
 
     return group;
   }
@@ -47,8 +48,7 @@ export class CavernSeerOpenerService {
     mesh.userData['cs:slice'] = true;
     mesh.name = slice.identifier.toString();
     const transform = float4x4ToMatrix4(slice.transform);
-    mesh.matrix.copy(transform);
-    mesh.matrixAutoUpdate = false;
+    mesh.applyMatrix4(transform)
     mesh.matrixWorldNeedsUpdate = true;
 
     return mesh;

--- a/src/app/shared/services/cavern-seer-opener.service.ts
+++ b/src/app/shared/services/cavern-seer-opener.service.ts
@@ -167,12 +167,12 @@ class ScanFileCoder extends KeyedUnarchiver<ScanFile> {
   decode(): ScanFile {
     const version = this.containsValue('version')
       ? this.decodeInt32('version')
-      : 1;
+      : 1n;
 
-    if (version === 1) {
-      throw new Error('Unfortunately cavernseerscan version 1 files are unsupported :(. Upgrade your file in CavernSeer to version 2 first.');
+    if (version === 1n) {
+      throw new Error('Unfortunately cavernseerscan version 1 files are unsupported 😔. Upgrade your file in CavernSeer to version 2 first.');
     }
-    if (version > 2) {
+    if (version > 2n) {
       throw new Error(`Unknown cavernseerscan version ${version}`);
     }
 

--- a/src/app/shared/services/cavern-seer-opener.service.ts
+++ b/src/app/shared/services/cavern-seer-opener.service.ts
@@ -148,7 +148,11 @@ export class CavernSeerOpenerService {
   }
 }
 
-
+/**
+ * Port of coder for CavernSeer's ScanFile.
+ *
+ * @link https://github.com/skgrush/CavernSeer/blob/e966eb/CavernSeer/Models/Serializations/ScanFile.swift
+ */
 class ScanFileCoder extends KeyedUnarchiver<ScanFile> {
 
   static readonly $classname = 'CavernSeer.ScanFile';
@@ -212,6 +216,11 @@ class ScanFileCoder extends KeyedUnarchiver<ScanFile> {
   }
 }
 
+/**
+ * Port of coder for CavernSeer's CSMeshSlice.
+ *
+ * @link https://github.com/skgrush/CavernSeer/blob/e966eb/CavernSeer/Models/Serializations/CSMeshSlice.swift
+ */
 class CSMeshSliceCoder extends KeyedUnarchiver<CSMeshSlice> {
 
   static readonly $classname = 'CavernSeer.CSMeshSlice';
@@ -238,6 +247,11 @@ class CSMeshSliceCoder extends KeyedUnarchiver<CSMeshSlice> {
   }
 }
 
+/**
+ * Port of coder for CavernSeer's CSMeshSnapshot.
+ *
+ * @link https://github.com/skgrush/CavernSeer/blob/e966eb/CavernSeer/Models/Serializations/CSMeshSnapshot.swift
+ */
 class CSMeshSnapshotCoder extends KeyedUnarchiver<CSMeshSnapshot> {
 
   static readonly $classname = 'CavernSeer.CSMeshSnapshot';
@@ -263,6 +277,11 @@ class CSMeshSnapshotCoder extends KeyedUnarchiver<CSMeshSnapshot> {
   }
 }
 
+/**
+ * Port of coder for CavernSeer's SurveyLine.
+ *
+ * @link https://github.com/skgrush/CavernSeer/blob/e966eb/CavernSeer/Models/Serializations/SurveyLine.swift
+ */
 class SurveyLineCoder extends KeyedUnarchiver<SurveyLine> {
 
   static readonly $classname = 'CavernSeer.SurveyLine';
@@ -285,6 +304,12 @@ class SurveyLineCoder extends KeyedUnarchiver<SurveyLine> {
     }
   }
 }
+
+/**
+ * Port of coder for CavernSeer's SurveyStation.
+ *
+ * @link https://github.com/skgrush/CavernSeer/blob/e966eb/CavernSeer/Models/Serializations/SurveyStation.swift
+ */
 class SurveyStationCoder extends KeyedUnarchiver<SurveyStation> {
 
   static readonly $classname = 'CavernSeer.SurveyStation';
@@ -308,6 +333,12 @@ class SurveyStationCoder extends KeyedUnarchiver<SurveyStation> {
     }
   }
 }
+
+/**
+ * Port of coder for CavernSeer's CSMeshGeometrySource.
+ *
+ * @link https://github.com/skgrush/CavernSeer/blob/e966eb/CavernSeer/Models/Serializations/CSMeshSlice.swift#L73
+ */
 class CSMeshGeometrySourceCoder extends KeyedUnarchiver<CSMeshGeometrySource> {
 
   static readonly $classname = 'CavernSeer.CSMeshGeometrySource';
@@ -336,6 +367,12 @@ class CSMeshGeometrySourceCoder extends KeyedUnarchiver<CSMeshGeometrySource> {
     };
   }
 }
+
+/**
+ * Port of coder for CavernSeer's CSMeshGeometryElement.
+ *
+ * @link https://github.com/skgrush/CavernSeer/blob/e966eb/CavernSeer/Models/Serializations/CSMeshSlice.swift#L171
+ */
 class CSMeshGeometryElementCoder extends KeyedUnarchiver<CSMeshGeometryElement> {
 
   static readonly $classname = 'CavernSeer.CSMeshGeometryElement';
@@ -362,6 +399,13 @@ class CSMeshGeometryElementCoder extends KeyedUnarchiver<CSMeshGeometryElement> 
   }
 }
 
+/**
+ * Mirror of CavernSeer's `NSCoder+simd.swift` implementation.
+ *
+ * Janky coder extensions I implemented before I knew that there were official simd coders.
+ *
+ * @link https://github.com/skgrush/CavernSeer/blob/e966eb/CavernSeer/extensions/NSCoder%2Bsimd.swift
+ */
 abstract class CavernSeerCustomDecoders {
   static decodeFloat3(coder: KeyedUnarchiver<any>, prefix: string) {
     const x = coder.decodeFloat(`${prefix}_x`);

--- a/src/app/shared/services/cavern-seer-opener.service.ts
+++ b/src/app/shared/services/cavern-seer-opener.service.ts
@@ -1,0 +1,389 @@
+import { Injectable } from '@angular/core';
+
+import { Reader, deStructWithIter } from '@skgrush/bplist-and-nskeyedunarchiver/bplist';
+import { UploadFileModel } from '../models/upload-file-model';
+import { KeyedUnarchiver, NSDateCoder, NSArrayCoder, NSUUIDCoder, Float4, Float4x4, $ObjectsMap, IArchivedInstance, IArchivedPList } from '@skgrush/bplist-and-nskeyedunarchiver/NSKeyedUnarchiver';
+import type { TransportProgressHandler } from '../models/transport-progress-handler';
+import type { CSMeshGeometryElement, CSMeshGeometrySource, CSMeshSlice, CSMeshSnapshot, ScanFile, SurveyLine, SurveyStation } from '../types/cavern-seer-scan';
+import { BufferAttribute, BufferGeometry, Group, Material, Mesh, MeshBasicMaterial } from 'three';
+
+
+@Injectable({
+  // necessary to be providedIn:root for dynamic injection
+  providedIn: 'root'
+})
+export class CavernSeerOpenerService {
+
+  async decode(file: UploadFileModel, progress?: TransportProgressHandler): Promise<ScanFile> {
+    return this.#parseBPListToScanFile(file, progress);
+  }
+
+  generateGroup(scanFile: ScanFile): Group {
+    const material = new MeshBasicMaterial({ color: 0xFF0000 });
+
+    const meshAnchors = scanFile.meshAnchors.map(slice => this.#meshSliceToGroup(slice, material));
+
+    const group = new Group();
+    group.children = meshAnchors;
+    group.userData['cs:encodingVersion'] = scanFile.name;
+    group.userData['encodingVersion'] = scanFile.encodingVersion;
+
+    return group;
+  }
+
+  #meshSliceToGroup(slice: CSMeshSlice, mat: Material) {
+    const geometry = new BufferGeometry();
+
+    slice.faces;
+
+    geometry.setIndex(this.#meshGeometryElementToFaces(slice.faces));
+    geometry.setAttribute('position', this.#meshGeometrySourceToVertices(slice.vertices));
+
+    const mesh = new Mesh(geometry, mat);
+    mesh.userData['cs:slice'] = true;
+    mesh.name = slice.identifier.toString();
+    const transform = slice.transform.flat() as [number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number];
+    mesh.matrix.set(...transform);
+
+    return mesh;
+  }
+
+  #meshGeometrySourceToVertices(src: CSMeshGeometrySource) {
+    const bitsPerComponent = 8 * Number(src.bytesPerComponent);
+    const count = Number(src.count);
+    if (src.format !== 30n) {
+      throw new Error(`CSMeshGeometrySource for vertices has incorrect format: MTLVertexFormat[${src.format}]`);
+    }
+    if (src.componentsPerVector !== 3n) {
+      throw new Error(`CSMeshGeometrySource for vertices expects 3 componentsPerVector, got ${src.componentsPerVector}`);
+    }
+    if (bitsPerComponent !== 32 && bitsPerComponent !== 64) {
+      throw new Error(`bad bits: ${bitsPerComponent}`);
+    }
+
+    return new BufferAttribute(this.#readDataToFloatArray(bitsPerComponent, src.data, src), 3);
+  }
+
+  #meshGeometryElementToFaces(src: CSMeshGeometryElement) {
+    const bytesPerComponent = Number(src.bytesPerIndex);
+    const bitsPerComponent = 8 * bytesPerComponent;
+    const indexCount = Number(src.count * src.indexCountPerPrimitive);
+
+    if (src.primitiveType !== 0n || src.indexCountPerPrimitive !== 3n) {
+      throw new Error(`CSMeshGeometryElement primitiveType should be 0 for triangles, got ${src.primitiveType}`);
+    }
+    if (bitsPerComponent !== 32/* && bitsPerComponent !== 64*/) {
+      throw new Error(`bad bits: ${bitsPerComponent}`);
+    }
+
+    const view = new DataView(src.data);
+    let i = 0;
+
+    const fn = (view: DataView, byteOffset: number) => ({ value: view.getInt32(byteOffset, true), bytesRead: bytesPerComponent });
+    function* elementIndexIter() {
+      for (; i < indexCount; ++i) {
+        yield fn;
+      }
+    }
+
+    const rawElementIter = [...deStructWithIter(elementIndexIter(), new DataView(src.data))];
+
+    return rawElementIter;
+  }
+
+  #readDataToFloatArray(bitsPerComponent: 32 | 64, data: ArrayBuffer, src: CSMeshGeometrySource) {
+    const elementCount = Number(src.count * src.componentsPerVector);
+
+    const deStructor = bitsPerComponent === 32
+      ? (view: DataView, byteOffset: number) => ({ value: view.getFloat32(byteOffset, true), bytesRead: 4 })
+      : (view: DataView, byteOffset: number) => ({ value: view.getFloat64(byteOffset, true), bytesRead: 8 });
+    function* elementIndexIter() {
+      for (let i = 0; i < elementCount; ++i) {
+        yield deStructor;
+      }
+    }
+
+    if (src.bytesPerComponent !== 4n || src.componentsPerVector !== 3n || src.offset !== 0n || src.stride !== 12n) {
+      debugger;
+    }
+
+    const rawElementIter = deStructWithIter(elementIndexIter(), new DataView(data));
+
+    const result = bitsPerComponent === 32
+      ? new Float32Array(rawElementIter)
+      : new Float64Array(rawElementIter);
+
+    return result;
+  }
+
+  async #parseBPListToScanFile(file: UploadFileModel, progress?: TransportProgressHandler) {
+    const archivedPlist = await this.#readTopObjectFromBPList(file);
+
+    progress?.setLoadPercent(0.60, 'Converting top-level object into ScanFile...');
+    return ScanFileCoder.unarchiveObject(ScanFileCoder, archivedPlist);
+  }
+
+  async #readTopObjectFromBPList(file: UploadFileModel, progress?: TransportProgressHandler) {
+    const reader = await this.#readBPList(file);
+
+    progress?.setLoadPercent(0.40, 'Converting unarchived-bplist into top-level object...');
+    const result = reader.buildTopLevelObject();
+    if (!result || typeof result !== 'object' || !('$archiver' in result)) {
+      throw new Error('Invalid cavernseerscan file');
+    }
+    // if (result['encodingVersion'] !== 2) {
+    //   throw new Error(`Expected cavernseerscan file encodingVersion 2 but got ${result['encodingVersion']}`);
+    // }
+
+    return result as IArchivedPList;
+  }
+
+  async #readBPList(file: UploadFileModel, progress?: TransportProgressHandler) {
+    progress?.setLoadPercent(0.10, 'Reading binary blob...');
+    const arrayBuffer = await file.blob.arrayBuffer();
+
+    progress?.setLoadPercent(0.20, 'Converting blob into unarchived-bplist...');
+    return new Reader(arrayBuffer);
+  }
+}
+
+
+class ScanFileCoder extends KeyedUnarchiver<ScanFile> {
+
+  static readonly $classname = 'CavernSeer.ScanFile';
+
+  constructor(
+    readonly $objects: $ObjectsMap,
+    readonly data: IArchivedInstance,
+  ) {
+    super();
+  }
+
+  static initForReadingDataFrom($objects: $ObjectsMap, data: IArchivedInstance) {
+    return new ScanFileCoder($objects, data);
+  }
+
+  decode(): ScanFile {
+    const version = this.containsValue('version')
+      ? this.decodeInt32('version')
+      : 1;
+
+    if (version === 1) {
+      throw new Error('Unfortunately cavernseerscan version 1 files are unsupported :(. Upgrade your file in CavernSeer to version 2 first.');
+    }
+    if (version > 2) {
+      throw new Error(`Unknown cavernseerscan version ${version}`);
+    }
+
+    const timestamp = this.decodeObjectOf(NSDateCoder, 'timestamp', true);
+    const name = this.decodeString('name', true);
+    const center = CavernSeerCustomDecoders.decodeFloat3(this, 'center');
+    const extent = CavernSeerCustomDecoders.decodeFloat3(this, 'extent');
+    const meshAnchors = this.decodeObjectOf([NSArrayCoder, CSMeshSliceCoder], 'meshAnchors', true) as CSMeshSlice[];
+    const startSnapshot = this.decodeSnapshot('startSnapshot');
+    const endSnapshot = this.decodeSnapshot('endSnapshot');
+    const stations = this.decodeObjectOf([NSArrayCoder, SurveyStationCoder], 'stations') as SurveyStation[] ?? [];
+    const lines = this.decodeObjectOf([NSArrayCoder, SurveyLineCoder], 'lines') as SurveyLine[] ?? [];
+    const location = null;
+
+    return {
+      encodingVersion: version,
+      timestamp,
+      name,
+      center,
+      extent,
+      meshAnchors,
+      startSnapshot,
+      endSnapshot,
+      stations,
+      lines,
+      // location,
+    }
+  }
+
+  private decodeSnapshot(key: string): CSMeshSnapshot | null {
+    if (!this.containsValue(key)) {
+      return null;
+    }
+
+    // assumes version === 2
+    return this.decodeObjectOf(CSMeshSnapshotCoder, key);
+  }
+}
+
+class CSMeshSliceCoder extends KeyedUnarchiver<CSMeshSlice> {
+
+  static readonly $classname = 'CavernSeer.CSMeshSlice';
+
+  constructor(
+    readonly $objects: $ObjectsMap,
+    readonly data: IArchivedInstance,
+  ) {
+    super();
+  }
+
+  static initForReadingDataFrom($objects: $ObjectsMap, data: IArchivedInstance) {
+    return new CSMeshSliceCoder($objects, data);
+  }
+
+  decode(): CSMeshSlice {
+    return {
+      identifier: this.decodeObjectOf(NSUUIDCoder, 'identifier', true),
+      transform: CavernSeerCustomDecoders.decodeFloat4x4(this, 'transform'),
+      vertices: this.decodeObjectOf(CSMeshGeometrySourceCoder, 'vertices', true),
+      faces: this.decodeObjectOf(CSMeshGeometryElementCoder, 'faces', true),
+      normals: this.decodeObjectOf(CSMeshGeometrySourceCoder, 'normals', true),
+    };
+  }
+}
+
+class CSMeshSnapshotCoder extends KeyedUnarchiver<CSMeshSnapshot> {
+
+  static readonly $classname = 'CavernSeer.CSMeshSnapshot';
+
+  constructor(
+    readonly $objects: $ObjectsMap,
+    readonly data: IArchivedInstance,
+  ) {
+    super();
+  }
+
+  static initForReadingDataFrom($objects: $ObjectsMap, data: IArchivedInstance) {
+    return new CSMeshSnapshotCoder($objects, data);
+  }
+
+  decode(): CSMeshSnapshot {
+    return {
+      imageData: this.decodeBytes('imageData', true),
+      transform: CavernSeerCustomDecoders.decodeFloat4x4(this, 'transform'),
+      identifier: this.decodeObjectOf(NSUUIDCoder, 'identifier', true),
+      name: this.decodeObject('name'),
+    };
+  }
+}
+
+class SurveyLineCoder extends KeyedUnarchiver<SurveyLine> {
+
+  static readonly $classname = 'CavernSeer.SurveyLine';
+
+  constructor(
+    readonly $objects: $ObjectsMap,
+    readonly data: IArchivedInstance,
+  ) {
+    super();
+  }
+
+  static initForReadingDataFrom($objects: $ObjectsMap, data: IArchivedInstance) {
+    return new SurveyLineCoder($objects, data);
+  }
+
+  decode(): SurveyLine {
+    return {
+      startIdentifier: this.decodeObjectOf(NSUUIDCoder, 'startId', true),
+      endIdentifier: this.decodeObjectOf(NSUUIDCoder, 'endId', true),
+    }
+  }
+}
+class SurveyStationCoder extends KeyedUnarchiver<SurveyStation> {
+
+  static readonly $classname = 'CavernSeer.SurveyStation';
+
+  constructor(
+    readonly $objects: $ObjectsMap,
+    readonly data: IArchivedInstance,
+  ) {
+    super();
+  }
+
+  static initForReadingDataFrom($objects: $ObjectsMap, data: IArchivedInstance) {
+    return new SurveyLineCoder($objects, data);
+  }
+
+  decode(): SurveyStation {
+    return {
+      identifier: this.decodeObjectOf(NSUUIDCoder, 'identifier', true),
+      transform: CavernSeerCustomDecoders.decodeFloat4x4(this, 'transform'),
+      name: this.decodeObject('name'),
+    }
+  }
+}
+class CSMeshGeometrySourceCoder extends KeyedUnarchiver<CSMeshGeometrySource> {
+
+  static readonly $classname = 'CavernSeer.CSMeshGeometrySource';
+
+  constructor(
+    readonly $objects: $ObjectsMap,
+    readonly data: IArchivedInstance,
+  ) {
+    super();
+  }
+
+  static initForReadingDataFrom($objects: $ObjectsMap, data: IArchivedInstance) {
+    return new CSMeshGeometrySourceCoder($objects, data);
+  }
+
+  decode(): CSMeshGeometrySource {
+    return {
+      bytesPerComponent: this.decodeInt32('bytesPerComponent'),
+      componentsPerVector: this.decodeInt32('componentsPerVector'),
+      count: this.decodeInt64('count'),
+      offset: this.decodeInt64('offset'),
+      stride: this.decodeInt64('stride'),
+      format: this.decodeInt64('format'),
+      data: this.decodeBytes('data', true),
+      semantic: this.decodeObject('semantic'),
+    };
+  }
+}
+class CSMeshGeometryElementCoder extends KeyedUnarchiver<CSMeshGeometryElement> {
+
+  static readonly $classname = 'CavernSeer.CSMeshGeometryElement';
+
+  constructor(
+    readonly $objects: $ObjectsMap,
+    readonly data: IArchivedInstance,
+  ) {
+    super();
+  }
+
+  static initForReadingDataFrom($objects: $ObjectsMap, data: IArchivedInstance) {
+    return new CSMeshGeometryElementCoder($objects, data);
+  }
+
+  decode(): CSMeshGeometryElement {
+    return {
+      data: this.decodeBytes('data', true),
+      primitiveType: this.decodeInt32('primitiveType'),
+      bytesPerIndex: this.decodeInt32('bytesPerIndex'),
+      count: this.decodeInt32('count'),
+      indexCountPerPrimitive: this.decodeInt32('indexCountPerPrimitive'),
+    };
+  }
+}
+
+abstract class CavernSeerCustomDecoders {
+  static decodeFloat3(coder: KeyedUnarchiver<any>, prefix: string) {
+    const x = coder.decodeFloat(`${prefix}_x`);
+    const y = coder.decodeFloat(`${prefix}_y`);
+    const z = coder.decodeFloat(`${prefix}_z`);
+
+    return [x, y, z] as const;
+  }
+
+  static decodeFloat4(coder: KeyedUnarchiver<any>, prefix: string): Float4 {
+    const x = coder.decodeFloat(`${prefix}_x`);
+    const y = coder.decodeFloat(`${prefix}_y`);
+    const z = coder.decodeFloat(`${prefix}_z`);
+    const w = coder.decodeFloat(`${prefix}_w`);
+    return [x, y, z, w];
+  }
+
+  static decodeFloat4x4(coder: KeyedUnarchiver<any>, prefix: string): Float4x4 {
+    const col0 = CavernSeerCustomDecoders.decodeFloat4(coder, `${prefix}_0`);
+    const col1 = CavernSeerCustomDecoders.decodeFloat4(coder, `${prefix}_1`);
+    const col2 = CavernSeerCustomDecoders.decodeFloat4(coder, `${prefix}_2`);
+    const col3 = CavernSeerCustomDecoders.decodeFloat4(coder, `${prefix}_3`);
+
+    return [col0, col1, col2, col3];
+  }
+}

--- a/src/app/shared/services/cavern-seer-opener.service.ts
+++ b/src/app/shared/services/cavern-seer-opener.service.ts
@@ -5,7 +5,7 @@ import { UploadFileModel } from '../models/upload-file-model';
 import { KeyedUnarchiver, NSDateCoder, NSArrayCoder, NSUUIDCoder, Float4, Float4x4, $ObjectsMap, IArchivedInstance, IArchivedPList } from '@skgrush/bplist-and-nskeyedunarchiver/NSKeyedUnarchiver';
 import type { TransportProgressHandler } from '../models/transport-progress-handler';
 import type { CSMeshGeometryElement, CSMeshGeometrySource, CSMeshSlice, CSMeshSnapshot, ScanFile, SurveyLine, SurveyStation } from '../types/cavern-seer-scan';
-import { BufferAttribute, BufferGeometry, Group, Material, Mesh, MeshBasicMaterial } from 'three';
+import { BufferAttribute, BufferGeometry, Group, Material, Matrix4, Mesh, MeshBasicMaterial, Vector3 } from 'three';
 
 
 @Injectable({
@@ -42,8 +42,12 @@ export class CavernSeerOpenerService {
     const mesh = new Mesh(geometry, mat);
     mesh.userData['cs:slice'] = true;
     mesh.name = slice.identifier.toString();
-    const transform = slice.transform.flat() as [number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number];
-    mesh.matrix.set(...transform);
+    // convert normal float4x4 to Matrix4
+    const transform = new Matrix4(...slice.transform.flat() as [number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number])
+      .transpose();
+    mesh.matrix.copy(transform);
+    mesh.matrixAutoUpdate = false;
+    mesh.matrixWorldNeedsUpdate = true;
 
     return mesh;
   }

--- a/src/app/shared/services/file-type.service.ts
+++ b/src/app/shared/services/file-type.service.ts
@@ -30,6 +30,9 @@ export class FileTypeService {
     if (this.isSupportedGroupArchive(mime, name)) {
       return FileModelType.group;
     }
+    if (this.isCavernSeerScan(mime, name)) {
+      return FileModelType.cavernseerscan;
+    }
     return FileModelType.unknown;
   }
 
@@ -64,5 +67,10 @@ export class FileTypeService {
 
   isSupportedGroupArchive(mime: string, name: string) {
     return this.isZip(mime, name);
+  }
+
+  isCavernSeerScan(mime: string, name: string) {
+    console.info('isCavernSeerScan', mime, name);
+    return this.getFileExtension(name) === '.cavernseerscan';
   }
 }

--- a/src/app/shared/services/file-type.service.ts
+++ b/src/app/shared/services/file-type.service.ts
@@ -70,7 +70,6 @@ export class FileTypeService {
   }
 
   isCavernSeerScan(mime: string, name: string) {
-    console.info('isCavernSeerScan', mime, name);
     return mime === 'application/vnd.org.grush.cavernseer.scan' || this.getFileExtension(name) === '.cavernseerscan';
   }
 }

--- a/src/app/shared/services/file-type.service.ts
+++ b/src/app/shared/services/file-type.service.ts
@@ -71,6 +71,6 @@ export class FileTypeService {
 
   isCavernSeerScan(mime: string, name: string) {
     console.info('isCavernSeerScan', mime, name);
-    return this.getFileExtension(name) === '.cavernseerscan';
+    return mime === 'application/vnd.org.grush.cavernseer.scan' || this.getFileExtension(name) === '.cavernseerscan';
   }
 }

--- a/src/app/shared/services/model-load.service.ts
+++ b/src/app/shared/services/model-load.service.ts
@@ -157,7 +157,9 @@ export class ModelLoadService {
 
     return this.#cavernSeerOpenerService$.pipe(
       switchMap(opener => {
-        return defer(() => opener.decode(file, progress)).pipe(
+        return defer(() =>
+          opener.decode(file, progress)
+        ).pipe(
           map((scanFile): IScanFileParsed => ({
             encodingVersion: scanFile.encodingVersion,
             timestamp: scanFile.timestamp,

--- a/src/app/shared/services/model-load.service.ts
+++ b/src/app/shared/services/model-load.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, Injector, Type, inject } from '@angular/core';
-import { MonoTypeOperatorFunction, Observable, catchError, defer, first, firstValueFrom, forkJoin, map, of, shareReplay, switchMap, tap, throwError } from 'rxjs';
-import { Loader } from 'three';
+import { Injectable, Injector, inject } from '@angular/core';
+import { Observable, catchError, defer, first, firstValueFrom, forkJoin, map, of, shareReplay, switchMap, tap, throwError } from 'rxjs';
+import { Group } from 'three';
 import { BaseModelManifest, ModelManifestV0, modelManifestParse } from '../models/model-manifest';
 import { FileModelType } from '../models/model-type.enum';
 import { AnyRenderModel } from '../models/render/any-render-model';
@@ -86,45 +86,55 @@ export class ModelLoadService {
     file: UploadFileModel,
     progress?: TransportProgressHandler,
   ): Observable<IModelLoadResult<ObjRenderModel>> {
-    const url = new URL(URL.createObjectURL(file.blob));
-    return this.#rawLoadObjFromUrl(url, progress).pipe(
-      this.#revokeUrlOnEnd(url),
-      map(({ result, errors }) => ({
-        errors,
-        result: result ? ObjRenderModel.fromUploadModel(file, result) : undefined,
+    return defer(() => file.blob.text()).pipe(
+      tap(() => progress?.addToLoadedCount(file.blob.size)),
+      switchMap(rawJson => this.#rawLoadObj(rawJson)),
+      map(group => ({
+        errors: [],
+        result: ObjRenderModel.fromUploadModel(file, group),
+      })),
+      catchError(err => of({
+        errors: [err],
       })),
     );
   }
 
-  #rawLoadObjFromUrl(
-    url: URL,
+  #rawLoadObj(
+    rawJson: string,
     progress?: TransportProgressHandler,
-  ) {
+  ): Observable<Group> {
     return this.#objLoader$.pipe(
-      switchMap(OBJLoader => this.#load(OBJLoader, url, progress)),
-    );
+      map(cls => new cls()),
+      map(loader => loader.parse(rawJson)),
+    )
   }
 
   loadGltf(
     file: UploadFileModel,
     progress?: TransportProgressHandler,
   ): Observable<IModelLoadResult<GltfRenderModel>> {
-    const url = new URL(URL.createObjectURL(file.blob));
-    return this.#rawLoadGltfFromUrl(url, progress).pipe(
-      this.#revokeUrlOnEnd(url),
-      map(({ result, errors }) => ({
-        errors,
+    return defer(() => file.blob.arrayBuffer()).pipe(
+      tap(() => progress?.addToLoadedCount(file.blob.size)),
+      switchMap(buffer => this.#rawLoadGltf(buffer)),
+      map(result => ({
+        errors: [],
         result: result ? GltfRenderModel.fromUploadModel(file, result) : undefined,
+      })),
+      catchError(err => of({
+        errors: [err],
       })),
     );
   }
 
-  #rawLoadGltfFromUrl(
-    url: URL,
+  #rawLoadGltf(
+    arrayBuffer: ArrayBuffer,
     progress?: TransportProgressHandler,
   ) {
     return this.#gltfLoader$.pipe(
-      switchMap(GLTFLoader => this.#load(GLTFLoader, url, progress))
+      map(cls => new cls()),
+      switchMap(loader => loader.parseAsync(arrayBuffer, '')),
+    );
+  }
     );
   }
 
@@ -294,49 +304,5 @@ export class ModelLoadService {
         },
       })),
     )
-  }
-
-  #load<TLoader extends Type<Loader>>(
-    loaderType: TLoader,
-    url: URL,
-    progress?: TransportProgressHandler,
-  ) {
-    type T = TLoader extends Type<Loader<infer TInner>> ? TInner : never;
-
-    return new Observable<{ result?: T, errors: Error[] }>(subscriber => {
-      let loadedSoFar = 0;
-      const loader = new loaderType();
-      loader.load(
-        url.toString(),
-        (data: any) => {
-          subscriber.next({
-            result: data,
-            errors: [],
-          });
-          subscriber.complete();
-        },
-        prog => {
-          const diff = prog.loaded - loadedSoFar;
-          loadedSoFar = prog.loaded;
-          progress?.addToLoadedCount(diff);
-        },
-        (error: any) => {
-          subscriber.next({
-            errors: [error],
-          });
-          subscriber.complete();
-        },
-      );
-    });
-  }
-
-  #revokeUrlOnEnd<T>(url: URL): MonoTypeOperatorFunction<T> {
-    const fn = () => {
-      URL.revokeObjectURL(url.toString())
-    };
-    return tap({
-      complete: fn,
-      error: fn,
-    });
   }
 }

--- a/src/app/shared/types/cavern-seer-scan.ts
+++ b/src/app/shared/types/cavern-seer-scan.ts
@@ -1,0 +1,64 @@
+import type { Uuid } from '@skgrush/bplist-and-nskeyedunarchiver/bplist';
+import type { Float3, Float4x4 } from '@skgrush/bplist-and-nskeyedunarchiver/NSKeyedUnarchiver';
+
+export type ScanFile = {
+  readonly encodingVersion: bigint;
+  readonly timestamp: Date;
+  readonly name: string;
+  readonly center: Float3;
+  readonly extent: Float3;
+  readonly meshAnchors: CSMeshSlice[];
+  readonly startSnapshot: CSMeshSnapshot | null;
+  readonly endSnapshot: CSMeshSnapshot | null;
+  readonly stations: SurveyStation[];
+  readonly lines: SurveyLine[];
+
+  // readonly location: CSLocation | null;
+}
+
+export type CSMeshSlice = {
+  readonly identifier: Uuid;
+  readonly transform: Float4x4;
+  readonly vertices: CSMeshGeometrySource;
+  readonly faces: CSMeshGeometryElement;
+  readonly normals: CSMeshGeometrySource;
+}
+
+export type CSMeshSnapshot = {
+  readonly imageData: ArrayBuffer;
+  readonly transform: Float4x4;
+  readonly identifier: Uuid;
+  readonly name: string | null;
+}
+
+export type SurveyLine = {
+  readonly startIdentifier: Uuid;
+  readonly endIdentifier: Uuid;
+}
+
+export type SurveyStation = {
+  readonly name: string;
+  readonly identifier: Uuid;
+  readonly transform: Float4x4;
+}
+
+export type CSMeshGeometrySource = {
+  readonly semantic: string;
+
+  readonly bytesPerComponent: bigint;
+  readonly componentsPerVector: bigint;
+
+  readonly data: ArrayBuffer;
+  readonly count: bigint;
+  readonly format: bigint;
+  readonly offset: bigint;
+  readonly stride: bigint;
+}
+
+export type CSMeshGeometryElement = {
+  readonly data: ArrayBuffer;
+  readonly bytesPerIndex: bigint;
+  readonly count: bigint;
+  readonly indexCountPerPrimitive: bigint;
+  readonly primitiveType: bigint;
+}


### PR DESCRIPTION
Version 0.3.0

Goals:
- [x] Add the ability to read CavernSeer scan files (the custom binary serializations from the CavernSeer app) with is encoded by NSKeyedUnarchiver

This drove me to build [@skgrush/BPlist-and-NSKeyedUnarchiver](https://github.com/skgrush/bplist-and-NSKeyedUnarchiver).

Core Changes:
* deserializer logic for `cavernseerscan` files with links to canonical Swift coders (see `cavern-seer-opener.service.ts`)
* New `CavernSeerScanRenderModel` for importing CavernSeer scans into the layer tree
   - shows survey lines and snapshots as temporary annotations

Additional changes:
* Explicitly filter out `TemporaryAnnotation`s when serializing annotations. This allows us to keep temporary annotations around.
* finally added support for GLTF files! Closes #11.
* remove `ModelLoadService#load` now that I've realized all ThreeJS loaders have `Loader#parseAsync()`