### PR TITLE
fix asset load URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavern-seer-mapper",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/skgrush/cavern-seer-mapper#readme",
   "license": "MIT",
   "author": {

--- a/src/app/shared/components/file-icon/file-icon.module.ts
+++ b/src/app/shared/components/file-icon/file-icon.module.ts
@@ -17,12 +17,12 @@ export class FileIconModule {
     registry.addSvgIconInNamespace(
       'svg',
       'glTF_White',
-      sanitizer.bypassSecurityTrustResourceUrl('/assets/icons/svg/glTF_White_June16.svg'),
+      sanitizer.bypassSecurityTrustResourceUrl('assets/icons/svg/glTF_White_June16.svg'),
     );
     registry.addSvgIconInNamespace(
       'svg',
       'CavernSeer',
-      sanitizer.bypassSecurityTrustResourceUrl('/assets/icons/fav/iconflat.svg'),
+      sanitizer.bypassSecurityTrustResourceUrl('assets/icons/fav/iconflat.svg'),
     );
   }
 }


### PR DESCRIPTION
Version 0.3.1.

I was loading dynamic icon assets with an absolute path but I should've used a relative path.