### PR TITLE
Visibility improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "homepage": "https://github.com/skgrush/cavern-seer-mapper#readme",
   "license": "MIT",
   "author": {

--- a/src/app/dialogs/cross-section-render-dialog/cross-section-render-dialog.component.html
+++ b/src/app/dialogs/cross-section-render-dialog/cross-section-render-dialog.component.html
@@ -2,8 +2,8 @@
 <div mat-dialog-content>
   <canvas #canvas></canvas>
   <button mat-icon-button (click)="toggleMaterial.click()" [matTooltip]="toggleMaterial.label">
-    <mat-icon *ngIf="toggleMaterial.fontSet$ | async as fontSet" [fontSet]="fontSet">
-      {{ toggleMaterial.icon }}
+    <mat-icon *ngIf="toggleMaterial.icon$ | async as icon" [fontSet]="icon.fontSet">
+      {{ icon.icon }}
     </mat-icon>
   </button>
   <mapper-cross-section-details-form [crossSection]="crossSection" [formGroup]="formGroup" />

--- a/src/app/dialogs/settings-dialog/settings-dialog.component.html
+++ b/src/app/dialogs/settings-dialog/settings-dialog.component.html
@@ -15,6 +15,15 @@
         </p>
       </section>
       <section>
+        <h2>Grid scale</h2>
+        <mat-button-toggle-group [formControl]="formGroup.controls.gridScale">
+          @for (scale of [1, 5, 10]; track scale) {
+            <mat-button-toggle [value]="scale">{{ scale }}</mat-button-toggle>
+          }
+        </mat-button-toggle-group>
+        <p>
+      </section>
+      <section>
         <h2>Byte format</h2>
         <mat-button-toggle-group [formControl]="formGroup.controls.byteFormat">
           <mat-button-toggle [value]="ByteFormatType.binary">binary</mat-button-toggle>

--- a/src/app/dialogs/settings-dialog/settings-dialog.component.ts
+++ b/src/app/dialogs/settings-dialog/settings-dialog.component.ts
@@ -32,6 +32,7 @@ export class SettingsDialogComponent implements OnInit {
   readonly formGroup = new FormGroup({
     measurementSystem: new FormControl(undefined as MeasurementSystem | undefined, { validators: [Validators.required], nonNullable: true }),
     byteFormat: new FormControl(undefined as ByteFormatType | undefined, { validators: [Validators.required], nonNullable: true }),
+    gridScale: new FormControl(undefined as number | undefined, { validators: [Validators.required], nonNullable: true }),
   });
 
   static open(dialog: MatDialog, injector: Injector) {

--- a/src/app/pages/right-tab-nav/cross-section-tab/cross-section-tab.component.html
+++ b/src/app/pages/right-tab-nav/cross-section-tab/cross-section-tab.component.html
@@ -1,6 +1,6 @@
 <p>
   Results of using
-  <mat-icon>{{ crossSectionTool.icon }}</mat-icon> {{ crossSectionTool.label }}
+  <mat-icon>{{ crossSectionTool.icon$ | async }}</mat-icon> {{ crossSectionTool.label }}
   tool
 </p>
 

--- a/src/app/pages/right-tab-nav/cross-section-tab/cross-section-tab.component.html
+++ b/src/app/pages/right-tab-nav/cross-section-tab/cross-section-tab.component.html
@@ -1,6 +1,6 @@
 <p>
   Results of using
-  <mat-icon>{{ crossSectionTool.icon$ | async }}</mat-icon> {{ crossSectionTool.label }}
+  <mat-icon>{{ (crossSectionTool.icon$ | async)?.icon }}</mat-icon> {{ crossSectionTool.label }}
   tool
 </p>
 

--- a/src/app/pages/right-tab-nav/measure-tabs/ceiling-tab/ceiling-tab.component.html
+++ b/src/app/pages/right-tab-nav/measure-tabs/ceiling-tab/ceiling-tab.component.html
@@ -1,5 +1,5 @@
 <p>Results of using
-  <mat-icon>{{ ceilingHeightTool.icon$ | async }}</mat-icon> {{ ceilingHeightTool.label }}
+  <mat-icon>{{ (ceilingHeightTool.icon$ | async)?.icon }}</mat-icon> {{ ceilingHeightTool.label }}
   tool
 </p>
 

--- a/src/app/pages/right-tab-nav/measure-tabs/ceiling-tab/ceiling-tab.component.html
+++ b/src/app/pages/right-tab-nav/measure-tabs/ceiling-tab/ceiling-tab.component.html
@@ -1,5 +1,5 @@
 <p>Results of using
-  <mat-icon>{{ ceilingHeightTool.icon }}</mat-icon> {{ ceilingHeightTool.label }}
+  <mat-icon>{{ ceilingHeightTool.icon$ | async }}</mat-icon> {{ ceilingHeightTool.label }}
   tool
 </p>
 

--- a/src/app/pages/right-tab-nav/measure-tabs/distance-measure-tab/distance-measure-tab.component.html
+++ b/src/app/pages/right-tab-nav/measure-tabs/distance-measure-tab/distance-measure-tab.component.html
@@ -1,5 +1,5 @@
 <p>Results of using
-  <mat-icon>{{ measureTool.icon$ | async }}</mat-icon> {{ measureTool.label }}
+  <mat-icon>{{ (measureTool.icon$ | async)?.icon }}</mat-icon> {{ measureTool.label }}
   tool
 </p>
 

--- a/src/app/pages/right-tab-nav/measure-tabs/distance-measure-tab/distance-measure-tab.component.html
+++ b/src/app/pages/right-tab-nav/measure-tabs/distance-measure-tab/distance-measure-tab.component.html
@@ -1,5 +1,5 @@
 <p>Results of using
-  <mat-icon>{{ measureTool.icon }}</mat-icon> {{ measureTool.label }}
+  <mat-icon>{{ measureTool.icon$ | async }}</mat-icon> {{ measureTool.label }}
   tool
 </p>
 

--- a/src/app/shared/components/model-detail-form/model-detail-form.component.html
+++ b/src/app/shared/components/model-detail-form/model-detail-form.component.html
@@ -1,7 +1,7 @@
 <form *ngIf="model.rendered">
   <div>
     <mat-checkbox [formControl]="formGroup.controls.visible">
-      <mat-icon>{{ formGroup.controls.visible ? 'visibility': 'visibility_off' }}</mat-icon>
+      <mat-icon>{{ formGroup.controls.visible.value ? 'visibility': 'visibility_off' }}</mat-icon>
       Visible
     </mat-checkbox>
   </div>

--- a/src/app/shared/components/model-detail-form/model-detail-form.component.html
+++ b/src/app/shared/components/model-detail-form/model-detail-form.component.html
@@ -1,4 +1,10 @@
 <form *ngIf="model.rendered">
+  <div>
+    <mat-checkbox [formControl]="formGroup.controls.visible">
+      <mat-icon>{{ formGroup.controls.visible ? 'visibility': 'visibility_off' }}</mat-icon>
+      Visible
+    </mat-checkbox>
+  </div>
   <mat-form-field>
     <mat-label>X</mat-label>
     <input matInput type="number" step="0.1" [formControl]="formGroup.controls.position.controls.x">

--- a/src/app/shared/components/model-detail-form/model-detail-form.component.scss
+++ b/src/app/shared/components/model-detail-form/model-detail-form.component.scss
@@ -5,3 +5,9 @@
 form {
   display: grid;
 }
+
+mat-checkbox {
+  mat-icon {
+    vertical-align: bottom;
+  }
+}

--- a/src/app/shared/components/model-nav-list/model-nav-list.component.html
+++ b/src/app/shared/components/model-nav-list/model-nav-list.component.html
@@ -8,7 +8,8 @@
     [class.hidden-node]="node.model.visible === false"
     (click)="selectModel($event, node)"
   >
-    <mapper-file-icon [type]="node.type" [class.hidden]="node.model.visible === false" /> <span>{{ node.identifier }}</span>
+    <mapper-file-icon [type]="node.type" [class.hidden]="node.model.visible === false" />
+    <span>{{ node.identifier }}</span>
   </mat-tree-node>
 
   <mat-nested-tree-node *matTreeNodeDef="let node; when: canHaveChildren">
@@ -19,7 +20,8 @@
       [class.hidden-node]="node.model.visible === false"
       (click)="selectModel($event, node)"
     >
-      <mapper-file-icon [type]="node.type" /> <span>{{ node.identifier }}</span>
+      <mapper-file-icon [type]="node.type" />
+      <span>{{ node.identifier }}</span>
     </div>
     <div class="children">
       <ng-container matTreeNodeOutlet />

--- a/src/app/shared/components/model-nav-list/model-nav-list.component.html
+++ b/src/app/shared/components/model-nav-list/model-nav-list.component.html
@@ -1,13 +1,24 @@
 <mat-tree class="model-nav-tree" [dataSource]="dataSource" [treeControl]="treeControl" [trackBy]="trackBy"
   (click)="selectModel($event, undefined)">
-  <mat-tree-node matRipple class="clickable-node" *matTreeNodeDef="let node"
-    [class.selected-node]="node.model === selectedModel.value" (click)="selectModel($event, node)">
-    <mapper-file-icon [type]="node.type" /> <span>{{ node.identifier }}</span>
+  <mat-tree-node
+    matRipple
+    class="clickable-node"
+    *matTreeNodeDef="let node"
+    [class.selected-node]="node.model === selectedModel.value"
+    [class.hidden-node]="node.model.visible === false"
+    (click)="selectModel($event, node)"
+  >
+    <mapper-file-icon [type]="node.type" [class.hidden]="node.model.visible === false" /> <span>{{ node.identifier }}</span>
   </mat-tree-node>
 
   <mat-nested-tree-node *matTreeNodeDef="let node; when: canHaveChildren">
-    <div class="mat-tree-node clickable-node" matRipple [class.selected-node]="node.model === selectedModel.value"
-      (click)="selectModel($event, node)">
+    <div
+      class="mat-tree-node clickable-node"
+      matRipple
+      [class.selected-node]="node.model === selectedModel.value"
+      [class.hidden-node]="node.model.visible === false"
+      (click)="selectModel($event, node)"
+    >
       <mapper-file-icon [type]="node.type" /> <span>{{ node.identifier }}</span>
     </div>
     <div class="children">
@@ -16,4 +27,7 @@
   </mat-nested-tree-node>
 </mat-tree>
 
-<mapper-model-detail-form *ngIf="selectedModel | async as selectedModel" [model]="selectedModel" />
+<div>
+  <mat-divider/>
+  <mapper-model-detail-form *ngIf="selectedModel | async as selectedModel" [model]="selectedModel" />
+</div>

--- a/src/app/shared/components/model-nav-list/model-nav-list.component.scss
+++ b/src/app/shared/components/model-nav-list/model-nav-list.component.scss
@@ -21,6 +21,11 @@
     &.selected-node {
       background-color: var(--mat-ripple-color);
     }
+    &.hidden-node {
+      mapper-file-icon {
+        opacity: 0.5;
+      }
+    }
   }
 }
 

--- a/src/app/shared/components/model-nav-list/model-nav-list.component.ts
+++ b/src/app/shared/components/model-nav-list/model-nav-list.component.ts
@@ -11,6 +11,7 @@ import { ModelDetailFormComponent } from "../model-detail-form/model-detail-form
 import { FileModelType } from '../../models/model-type.enum';
 import { FileIconComponent } from '../file-icon/file-icon.component';
 import { MatRippleModule } from '@angular/material/core';
+import {MatDividerModule} from "@angular/material/divider";
 
 interface INode {
   identifier: string;
@@ -36,7 +37,7 @@ function transformToNode(model: BaseRenderModel<any>): INode {
   templateUrl: './model-nav-list.component.html',
   styleUrl: './model-nav-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatTreeModule, NgIf, AsyncPipe, ModelDetailFormComponent, FileIconComponent, MatRippleModule]
+  imports: [MatTreeModule, NgIf, AsyncPipe, ModelDetailFormComponent, FileIconComponent, MatRippleModule, MatDividerModule]
 })
 export class ModelNavListComponent {
 

--- a/src/app/shared/components/tools-bar/tools-bar.component.html
+++ b/src/app/shared/components/tools-bar/tools-bar.component.html
@@ -7,10 +7,22 @@
 </mat-button-toggle-group>
 
 <div class="standalone-buttons">
-  @for (tool of nonExclusiveTools; track tool) {
-  <button mat-flat-button (click)="tool.click()" [matTooltip]="tool.label">
-    <mat-icon *ngIf="tool.icon$ | async as icon" [fontSet]="icon.fontSet ?? 'material-icons'">{{ icon.icon }}</mat-icon>
-  </button>
-  }
+<!--  @for (tool of nonExclusiveTools; track tool) {-->
+<!--  <button mat-flat-button (click)="tool.click()" [matTooltip]="tool.label">-->
+<!--    <mat-icon *ngIf="tool.icon$ | async as icon" [fontSet]="icon.fontSet ?? 'material-icons'">{{ icon.icon }}</mat-icon>-->
+<!--  </button>-->
+<!--  }-->
 
+  <button mat-flat-button [matMenuTriggerFor]="standaloneMenu" [matTooltip]="'Additional tools'">
+    <mat-icon>expand_less</mat-icon>
+  </button>
+
+  <mat-menu #standaloneMenu="matMenu">
+    @for (tool of nonExclusiveTools; track tool) {
+    <button mat-menu-item (click)="tool.click()" [matTooltip]="tool.label">
+      <mat-icon *ngIf="tool.icon$ | async as icon" [fontSet]="icon.fontSet ?? 'material-icons'">{{ icon.icon }}</mat-icon>
+      <span>{{ tool.label }}</span>
+    </button>
+    }
+  </mat-menu>
 </div>

--- a/src/app/shared/components/tools-bar/tools-bar.component.html
+++ b/src/app/shared/components/tools-bar/tools-bar.component.html
@@ -1,7 +1,7 @@
 <mat-button-toggle-group [ngModel]="currentTool$ | async" (ngModelChange)="selectTool($event)">
-  @for (entry of toolOptions; track entry) {
-  <mat-button-toggle [value]="entry.id" [aria-label]="entry.label" [matTooltip]="entry.label">
-    <mat-icon>{{ entry.icon }}</mat-icon>
+  @for (tool of toolOptions; track tool) {
+  <mat-button-toggle [value]="tool.id" [aria-label]="tool.label" [matTooltip]="tool.label">
+    <mat-icon *ngIf="tool.icon$ | async as icon" [fontSet]="icon.fontSet ?? 'material-icons'">{{ icon.icon }}</mat-icon>
   </mat-button-toggle>
   }
 </mat-button-toggle-group>
@@ -9,7 +9,7 @@
 <div class="standalone-buttons">
   @for (tool of nonExclusiveTools; track tool) {
   <button mat-flat-button (click)="tool.click()" [matTooltip]="tool.label">
-    <mat-icon *ngIf="tool.fontSet$ | async as fontSet" [fontSet]="fontSet">{{ tool.icon }}</mat-icon>
+    <mat-icon *ngIf="tool.icon$ | async as icon" [fontSet]="icon.fontSet ?? 'material-icons'">{{ icon.icon }}</mat-icon>
   </button>
   }
 

--- a/src/app/shared/components/tools-bar/tools-bar.component.ts
+++ b/src/app/shared/components/tools-bar/tools-bar.component.ts
@@ -6,11 +6,12 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { ToolManagerService } from '../../services/tool-manager.service';
+import {MatMenuModule} from "@angular/material/menu";
 
 @Component({
   selector: 'mapper-tools-bar',
   standalone: true,
-  imports: [MatButtonToggleModule, MatButtonModule, MatIconModule, FormsModule, AsyncPipe, MatTooltipModule, NgIf],
+  imports: [MatButtonToggleModule, MatButtonModule, MatIconModule, FormsModule, AsyncPipe, MatTooltipModule, NgIf, MatMenuModule],
   templateUrl: './tools-bar.component.html',
   styleUrl: './tools-bar.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/shared/models/annotations/ceiling-height.annotation.ts
+++ b/src/app/shared/models/annotations/ceiling-height.annotation.ts
@@ -116,13 +116,18 @@ export class CeilingHeightAnnotation extends BaseAnnotation {
 
     const circleSize = centerOffset * 1.1;
     const circleGeometry = new CircleGeometry(circleSize, 24);
-    const circleMesh = new Mesh(circleGeometry, new MeshBasicMaterial({ color: 0xFFFFFF }));
+    const circleMaterial = new MeshBasicMaterial({ color: 0xFFFFFF })
+    const circleMesh = new Mesh(circleGeometry, circleMaterial);
     circleMesh.position.set(0, this.distance, 0);
     circleMesh.rotation.set(-Math.PI / 2, 0, 0);
 
-    const textMesh = new Mesh(textGeometry, new MeshBasicMaterial({ color: 0x00 }));
+    const textMaterial = new MeshBasicMaterial({ color: 0x00 });
+    const textMesh = new Mesh(textGeometry, textMaterial);
     textMesh.position.set(centerOffset, this.distance + size / 5, size / 2);
     textMesh.rotation.set(-Math.PI / 2, 0, 0);
+
+    [textMaterial, circleMaterial].forEach(mat => mat.depthTest = false);
+    [circleMesh, textMesh].forEach(mesh => mesh.renderOrder = RenderingOrder.Annotation);
 
     return {
       circleMesh,

--- a/src/app/shared/models/annotations/cross-section.annotation.ts
+++ b/src/app/shared/models/annotations/cross-section.annotation.ts
@@ -146,10 +146,10 @@ export class CrossSectionAnnotation extends BaseAnnotation {
       return;
     }
 
-    for (let i = 0; i < this.#measureLines.length; ++i) {
-      const line = this.#measureLines[i];
+    for (let offset = 0; offset < this.#measureLines.length; ++offset) {
+      const line = this.#measureLines[offset];
       line.geometry.setFromPoints([
-        ...this.#getMeasureLinePoints(i),
+        ...this.#getMeasureLinePoints(offset),
       ]);
       line.computeLineDistances();
       line.position.set(0, -this.dimensions.y / 2 + 0.5, -0.5);

--- a/src/app/shared/models/render/base.render-model.ts
+++ b/src/app/shared/models/render/base.render-model.ts
@@ -32,6 +32,8 @@ export abstract class BaseRenderModel<T extends FileModelType> {
 }
 
 export abstract class BaseVisibleRenderModel<T extends FileModelType> extends BaseRenderModel<T> {
+  abstract readonly visible: boolean;
+
   abstract getAnnotations(): readonly BaseAnnotation[];
 
   /**
@@ -47,6 +49,7 @@ export abstract class BaseVisibleRenderModel<T extends FileModelType> extends Ba
   abstract setMaterial(material: BaseMaterialService<any>): void;
 
   abstract setPosition(pos: ISimpleVector3): boolean;
+  abstract setVisibility(visible: boolean): void;
 
   override setFromManifest(manifest: BaseModelManifest, path: string, annoBuilder: AnnotationBuilderService): Error[] {
     const pos = manifest.getPosition(path);

--- a/src/app/shared/models/render/cavern-seer-scan.render-model.ts
+++ b/src/app/shared/models/render/cavern-seer-scan.render-model.ts
@@ -267,7 +267,7 @@ export class CavernSeerScanRenderModel extends BaseVisibleRenderModel<FileModelT
     const mesh = new Mesh(new PlaneGeometry(width / height, 1), material);
 
     mesh.userData['cs:snapshot'] = true;
-    mesh.userData['cs:identifier'] = snapshot.identifier;
+    mesh.userData['cs:identifier'] = snapshot.identifier.toString();
     mesh.userData['cs:name'] = snapshot.name;
 
     // pre-rotate because exif nonsense

--- a/src/app/shared/models/render/cavern-seer-scan.render-model.ts
+++ b/src/app/shared/models/render/cavern-seer-scan.render-model.ts
@@ -37,6 +37,9 @@ export class CavernSeerScanRenderModel extends BaseVisibleRenderModel<FileModelT
   override get position() {
     return this.#group.position;
   }
+  override get visible() {
+    return this.#group.visible;
+  }
 
   readonly #blob: Blob;
   readonly #parsedScanFile: IScanFileParsed;
@@ -104,6 +107,12 @@ export class CavernSeerScanRenderModel extends BaseVisibleRenderModel<FileModelT
       }
     });
   }
+
+  override setVisibility(visible: boolean) {
+    this.#group.visible = visible;
+    markSceneOfItemForReRender(this.#group);
+  }
+
   override addToGroup(group: Group<Object3DEventMap>): void {
     if (this.#group.parent !== null) {
       throw new Error('attempt to add CavernSeerScanRenderModel to group while model already has a parent');

--- a/src/app/shared/models/render/gltf.render-model.ts
+++ b/src/app/shared/models/render/gltf.render-model.ts
@@ -9,6 +9,7 @@ import { UploadFileModel } from "../upload-file-model";
 import { BaseAnnotation } from "../annotations/base.annotation";
 import { ModelChangeType } from "../model-change-type.enum";
 import { IMapperUserData } from "../user-data";
+import {markSceneOfItemForReRender} from "../../functions/mark-scene-of-item-for-rerender";
 
 /**
  * TODO: #11: https://github.com/skgrush/cavern-seer-mapper/issues/11
@@ -24,6 +25,9 @@ export class GltfRenderModel extends BaseVisibleRenderModel<FileModelType.gLTF> 
 
   override get position(): Readonly<Vector3> {
     return this.#gltf.scene.position;
+  }
+  override get visible() {
+    return this.#gltf.scene.visible;
   }
 
   readonly #blob: Blob;
@@ -87,6 +91,11 @@ export class GltfRenderModel extends BaseVisibleRenderModel<FileModelType.gLTF> 
         child.material = material.material;
       }
     });
+  }
+
+  override setVisibility(visible: boolean) {
+    this.#gltf.scene.visible = visible;
+    markSceneOfItemForReRender(this.#gltf.scene);
   }
 
   override addToGroup(group: Group<Object3DEventMap>): void {

--- a/src/app/shared/models/render/group.render-model.ts
+++ b/src/app/shared/models/render/group.render-model.ts
@@ -19,6 +19,9 @@ export class GroupRenderModel extends BaseVisibleRenderModel<FileModelType.group
   override get position() {
     return this.#group.position;
   }
+  override get visible() {
+    return this.#group.visible;
+  }
 
   readonly #group = new Group();
   readonly #annotations = new Set<BaseAnnotation>();
@@ -138,6 +141,12 @@ export class GroupRenderModel extends BaseVisibleRenderModel<FileModelType.group
       }
     }
   }
+
+  override setVisibility(visible: boolean) {
+    this.#group.visible = visible;
+    markSceneOfItemForReRender(this.#group);
+  }
+
   override addToGroup(group: Group<Object3DEventMap>): void {
     if (this.#group.parent !== null) {
       throw new Error('attempted to add GroupRenderModel to group while model already has parent');

--- a/src/app/shared/models/render/obj.render-model.ts
+++ b/src/app/shared/models/render/obj.render-model.ts
@@ -8,6 +8,7 @@ import { UploadFileModel } from "../upload-file-model";
 import { BaseAnnotation } from "../annotations/base.annotation";
 import { IMapperUserData } from "../user-data";
 import { ModelChangeType } from "../model-change-type.enum";
+import {markSceneOfItemForReRender} from "../../functions/mark-scene-of-item-for-rerender";
 
 export class ObjRenderModel extends BaseVisibleRenderModel<FileModelType.obj> {
   override readonly type = FileModelType.obj;
@@ -18,6 +19,9 @@ export class ObjRenderModel extends BaseVisibleRenderModel<FileModelType.obj> {
   override readonly rendered = true;
   override get position() {
     return this.#object.position;
+  }
+  override get visible() {
+    return this.#object.visible;
   }
 
   readonly #object: Group;
@@ -77,6 +81,11 @@ export class ObjRenderModel extends BaseVisibleRenderModel<FileModelType.obj> {
         child.material = material.material;
       }
     });
+  }
+
+  override setVisibility(visible: boolean) {
+    this.#object.visible = visible;
+    markSceneOfItemForReRender(this.#object);
   }
 
   override addToGroup(group: Group): void {

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -215,6 +215,7 @@ export class CanvasService {
       canvas,
       preserveDrawingBuffer: true,
       antialias: true,
+      alpha: true,
     });
 
     // set the size but without setting styles, as OffscreenCanvas has no style

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -47,6 +47,9 @@ export class CanvasService {
   readonly #materialSideSubject = new BehaviorSubject<Side>(FrontSide);
   readonly materialSide$ = this.#materialSideSubject.asObservable();
 
+  readonly #gridVisibleSubject = new BehaviorSubject(true);
+  readonly gridVisible$ = this.#gridVisibleSubject.asObservable();
+
   #bottomGrid = new GridHelper();
 
   #currentGroupInScene?: GroupRenderModel;
@@ -94,6 +97,13 @@ export class CanvasService {
       const bounds = cog.getBoundingBox();
       this.#rebuildBottomGrid(bounds);
     });
+
+    this.gridVisible$.pipe(
+      takeUntilDestroyed()
+    ).subscribe(visible => {
+      this.#bottomGrid.visible = visible;
+      markSceneOfItemForReRender(this.#bottomGrid);
+    })
   }
 
   /**
@@ -126,6 +136,12 @@ export class CanvasService {
       this.#material.toggleDoubleSide()
     );
     markSceneOfItemForReRender(this.#scene);
+  }
+
+  toggleGridVisible() {
+    this.#gridVisibleSubject.next(
+      !this.#gridVisibleSubject.value,
+    );
   }
 
   /**
@@ -360,6 +376,7 @@ export class CanvasService {
       zDelta = this.#localize.localLengthToMeters(Math.round(this.#localize.metersToLocalLength(zDelta)));
     }
 
+    gridHelper.visible = this.#gridVisibleSubject.value;
     gridHelper.position.set(
       boundsMin.x + xDelta,
       boundsMin.y,

--- a/src/app/shared/services/cavern-seer-opener.service.ts
+++ b/src/app/shared/services/cavern-seer-opener.service.ts
@@ -36,7 +36,7 @@ export class CavernSeerOpenerService {
     group.add(...meshAnchors);
     group.name = scanFile.name;
     group.userData['cs:timestamp'] = scanFile.timestamp;
-    group.userData['cs:encodingVersion'] = scanFile.encodingVersion;
+    group.userData['cs:encodingVersion'] = Number(scanFile.encodingVersion);
     group.matrixWorldNeedsUpdate = true;
 
     return group;

--- a/src/app/shared/services/settings/settings.service.ts
+++ b/src/app/shared/services/settings/settings.service.ts
@@ -30,6 +30,10 @@ export class SettingsService {
     map(s => s.byteFormat),
     distinctUntilChanged(),
   );
+  readonly gridScale$ = this.state$.pipe(
+    map(s => s.gridScale),
+    distinctUntilChanged(),
+  );
 
   get measurementSystem() {
     return this.#stateSnapshot.measurementSystem;

--- a/src/app/shared/services/settings/state.ts
+++ b/src/app/shared/services/settings/state.ts
@@ -6,6 +6,7 @@ export type ISettingsState = {
   readonly initialized: boolean;
   readonly measurementSystem: MeasurementSystem;
   readonly byteFormat: ByteFormatType;
+  readonly gridScale: number,
 };
 export type StateOtherThanInitialize = Omit<ISettingsState, 'initialized'>;
 
@@ -13,6 +14,7 @@ export const initialState = {
   initialized: false,
   measurementSystem: MeasurementSystem.metric,
   byteFormat: ByteFormatType.binary,
+  gridScale: 1,
 } as const satisfies ISettingsState;
 
 export const SettingsActions = createActionGroup({
@@ -21,6 +23,7 @@ export const SettingsActions = createActionGroup({
     'Initialize': props<{ partialState: Partial<StateOtherThanInitialize> }>(),
     'Update measurementSystem': props<{ measurementSystem: MeasurementSystem }>(),
     'Update byteFormat': props<{ byteFormat: ByteFormatType }>(),
+    'Update gridScale': props<{ gridScale: number }>(),
   },
 });
 
@@ -40,6 +43,10 @@ export const SettingsFeture = createFeature({
     on(SettingsActions.updateByteFormat, (state, { byteFormat }) => ({
       ...state,
       byteFormat,
+    })),
+    on(SettingsActions.updateGridScale, (state, { gridScale }) => ({
+      ...state,
+      gridScale,
     })),
   ),
 });

--- a/src/app/shared/services/tool-manager.service.ts
+++ b/src/app/shared/services/tool-manager.service.ts
@@ -17,8 +17,7 @@ export class ToolManagerService {
   readonly currentToolId$ = this.#currentTool.pipe(map(t => t.id));
   readonly currentToolCursor$ = this.#currentTool.pipe(switchMap(t => t.cursor$));
 
-  readonly exclusiveToolOptions = [...this.#exclusiveTools.values()]
-    .map(({ id, label, icon }) => ({ id, label, icon } as const));
+  readonly exclusiveToolOptions = [...this.#exclusiveTools.values()];
   readonly nonExclusiveTools = Object.freeze([...this.#nonexclusiveTools]);
 
   /**

--- a/src/app/shared/services/tools/base-tool.service.ts
+++ b/src/app/shared/services/tools/base-tool.service.ts
@@ -4,12 +4,15 @@ import { Observable, of } from "rxjs";
 export const EXCLUSIVE_TOOL_SERVICES = new InjectionToken<readonly BaseExclusiveToolService[]>('exclusive-tool-services');
 export const NONEXCLUSIVE_TOOL_SERVICES = new InjectionToken<readonly BaseClickToolService[]>('non-exclusive-tool-services');
 
+export type Icon$Type = {
+  readonly icon: string;
+  readonly fontSet?: 'material-icons' | 'material-icons-outlined';
+}
+
 export abstract class BaseToolService {
   abstract readonly id: string;
   abstract readonly label: string;
-  abstract readonly icon: string;
-
-  readonly fontSet$: Observable<'material-icons' | 'material-icons-outlined'> = of('material-icons');
+  abstract readonly icon$: Observable<Icon$Type>;
 }
 
 export abstract class BaseClickToolService extends BaseToolService {

--- a/src/app/shared/services/tools/ceiling-height-tool.service.ts
+++ b/src/app/shared/services/tools/ceiling-height-tool.service.ts
@@ -25,7 +25,7 @@ export class CeilingHeightToolService extends BaseExclusiveToolService {
 
   override readonly id = 'ceiling-height';
   override readonly label = 'Ceiling height';
-  override readonly icon = 'biotech';
+  override readonly icon$ = of({ icon: 'biotech' });
   override readonly cursor$ = of('crosshair');
 
   constructor() {

--- a/src/app/shared/services/tools/cross-section-tool.service.ts
+++ b/src/app/shared/services/tools/cross-section-tool.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { BehaviorSubject, Subject, distinctUntilChanged, filter, merge, switchMap, takeUntil, tap } from 'rxjs';
+import {BehaviorSubject, Subject, distinctUntilChanged, filter, merge, switchMap, takeUntil, tap, of} from 'rxjs';
 import { BufferGeometry, GridHelper, Intersection, Line, LineBasicMaterial, Vector2, Vector3 } from 'three';
 import { markSceneOfItemForReRender } from '../../functions/mark-scene-of-item-for-rerender';
 import { normalizeCanvasCoords } from '../../functions/normalize-canvas-coords';
@@ -36,7 +36,7 @@ export class CrossSectionToolService extends BaseExclusiveToolService {
 
   override readonly id = 'cross-section';
   override readonly label = 'Cross section';
-  override readonly icon = 'looks';
+  override readonly icon$ = of({ icon: 'looks' });
   override readonly cursor$ = this.#cursor.pipe(distinctUntilChanged());
 
   #currentModelRef?: WeakRef<GroupRenderModel>;

--- a/src/app/shared/services/tools/distance-measure-tool.service.ts
+++ b/src/app/shared/services/tools/distance-measure-tool.service.ts
@@ -28,7 +28,7 @@ export class DistanceMeasureToolService extends BaseExclusiveToolService {
 
   override readonly id = 'distance';
   override readonly label = 'Distance measure';
-  override readonly icon = 'square_foot';
+  override readonly icon$ = of({ icon: 'square_foot' });
   override readonly cursor$ = of('crosshair');
 
   constructor() {

--- a/src/app/shared/services/tools/index.ts
+++ b/src/app/shared/services/tools/index.ts
@@ -5,6 +5,7 @@ import { EXCLUSIVE_TOOL_SERVICES, NONEXCLUSIVE_TOOL_SERVICES } from "./base-tool
 import { CeilingHeightToolService } from "./ceiling-height-tool.service";
 import { CrossSectionToolService } from "./cross-section-tool.service";
 import { ToggleMaterialSidesToolService } from "./toggle-material-sides-tool.service";
+import {ToggleGridToolService} from "./toggle-grid-tool.service";
 
 const services = [DistanceMeasureToolService, NoToolService];
 
@@ -15,10 +16,12 @@ export function toolsProviders() {
     CeilingHeightToolService,
     CrossSectionToolService,
     ToggleMaterialSidesToolService,
+    ToggleGridToolService,
     { provide: EXCLUSIVE_TOOL_SERVICES, useExisting: NoToolService, multi: true },
     { provide: EXCLUSIVE_TOOL_SERVICES, useExisting: DistanceMeasureToolService, multi: true },
     { provide: EXCLUSIVE_TOOL_SERVICES, useExisting: CeilingHeightToolService, multi: true },
     { provide: EXCLUSIVE_TOOL_SERVICES, useExisting: CrossSectionToolService, multi: true },
     { provide: NONEXCLUSIVE_TOOL_SERVICES, useExisting: ToggleMaterialSidesToolService, multi: true },
+    { provide: NONEXCLUSIVE_TOOL_SERVICES, useExisting: ToggleGridToolService, multi: true },
   ]);
 }

--- a/src/app/shared/services/tools/no-tool.service.ts
+++ b/src/app/shared/services/tools/no-tool.service.ts
@@ -7,7 +7,7 @@ export class NoToolService extends BaseExclusiveToolService {
 
   override readonly id = 'no-tool';
   override readonly label = 'No tool';
-  override readonly icon = 'open_with';
+  override readonly icon$ = of({ icon: 'open_with' });
   override readonly cursor$ = of('grab');
 
   override start() {

--- a/src/app/shared/services/tools/toggle-grid-tool.service.ts
+++ b/src/app/shared/services/tools/toggle-grid-tool.service.ts
@@ -1,0 +1,21 @@
+import {inject, Injectable} from '@angular/core';
+import {BaseClickToolService} from "./base-tool.service";
+import {map} from "rxjs";
+import {CanvasService} from "../canvas.service";
+
+@Injectable()
+export class ToggleGridToolService extends BaseClickToolService {
+  readonly #canvasService = inject(CanvasService);
+
+  override readonly id = 'toggle-grid';
+  override readonly label = 'Toggle grid';
+  override readonly icon$ = this.#canvasService.gridVisible$.pipe(
+    map(visible => ({
+      icon: visible ? 'grid_on' : 'grid_off',
+    })),
+  );
+
+  override click() {
+    this.#canvasService.toggleGridVisible();
+  }
+}

--- a/src/app/shared/services/tools/toggle-material-sides-tool.service.ts
+++ b/src/app/shared/services/tools/toggle-material-sides-tool.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, inject } from "@angular/core";
-import { map } from "rxjs";
+import {map, Observable} from "rxjs";
 import { FrontSide } from "three";
 import { CanvasService } from "../canvas.service";
-import { BaseClickToolService } from "./base-tool.service";
+import {BaseClickToolService, Icon$Type} from "./base-tool.service";
 
 @Injectable()
 export class ToggleMaterialSidesToolService extends BaseClickToolService {
@@ -10,18 +10,13 @@ export class ToggleMaterialSidesToolService extends BaseClickToolService {
 
   override readonly id = 'toggle-material-sides';
   override readonly label = 'Toggle double-sided';
-  override readonly icon = 'layers';
 
-  override readonly fontSet$ =
+  override readonly icon$ =
     this.#canvasService.materialSide$.pipe(
-      map(side => {
-        switch (side) {
-          case FrontSide:
-            return 'material-icons-outlined';
-          default:
-            return 'material-icons';
-        }
-      }),
+      map((side) => ({
+          icon: 'layers',
+          fontSet: side === FrontSide ? 'material-icons-outlined' : 'material-icons',
+        } as const)),
     );
 
   override click() {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -40,3 +40,17 @@ mat-snack-bar-container {
     }
   }
 }
+
+
+// disable the little spinner UI elements on number boxes
+mat-form-field input[type="number"] {
+  -moz-appearance: textfield;
+  -webkit-appearance: textfield;
+  appearance: textfield;
+
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+}


### PR DESCRIPTION
Goals:
- [x] close #33 by allowing toggling layer visibility
   * accessible through the details form on layers which are visible in the render, with a checkbox and an eye icon
   * all `BaseVisibleRenderModel`s now have a `visible` property and `setVisibility(visible)` meethod
- [x] close #28 by allowing changing grid scaling
    * currently only allows changing to 1/5/10 unit scales
    * is stored in local storage settings
- [x] close #29 by allowing toggling grid visibility
- [x] closes #27 by changing cross-section scale bar to alternate black-and-white
    * implemented with `LineSegments` 
    <img width="160" alt="image" src="https://github.com/skgrush/cavern-seer-mapper/assets/21208885/40598be1-2197-4fec-ba56-a1fa2a932635">


Other major changes:
 * non-exclusive tools are now all in one menu icon, better for mobile
 * ceiling height annotations are now rendered on the annotation layer above/through meshes

Other minor changes:
* tools `icon` is now `icon$` and contains both an icon name and optionally a fontSet, allowing either to change
* fixed an issue `CavernSeerScanRenderModel`s not being copyable/serializable due to usage of `BigInt`s in `userData`
* resizing the grid is now more responsive; this is basically no change, as the only new trigger is `SettingsService#gridScale$` which only changes when reloading the page. This'll be more useful in the future.
* disabled those little spinner UI elements on number boxes