### PR TITLE
Experimentally allow loading Walls files.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavern-seer-mapper",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "homepage": "https://github.com/skgrush/cavern-seer-mapper#readme",
   "license": "MIT",
   "author": {

--- a/src/app/pages/sidenav/sidenav.component.html
+++ b/src/app/pages/sidenav/sidenav.component.html
@@ -10,7 +10,7 @@
   <p>{{ mapperVersion.version }}</p>
   <p>
     <a [style.color]="'white'"
-      [href]="'https://github.com/skgrush/cavern-seer-mapper/releases/tag/v' + mapperVersion.version">
+      [href]="'https://github.com/skgrush/cavern-seer-mapper/releases/tag/v' + mapperVersion.packageVersion">
       View on GitHub
     </a>
   </p>

--- a/src/app/shared/components/file-icon/file-icon.component.ts
+++ b/src/app/shared/components/file-icon/file-icon.component.ts
@@ -22,6 +22,7 @@ export class FileIconComponent {
     gltf: 'svg:glTF_White',
     obj: 'shape_line',
     cavernseerscan: 'svg:CavernSeer',
+    walls: 'ssid_chart',
   } satisfies Record<FileModelType, string>);
 
 

--- a/src/app/shared/functions/primitiveWallsFileParse.ts
+++ b/src/app/shared/functions/primitiveWallsFileParse.ts
@@ -1,0 +1,173 @@
+import {Color, Vector3} from "three";
+
+export type PrimitiveWallsMaterial = {
+  readonly emissiveColor: Color;
+  readonly diffuseColor: Color;
+};
+export type PrimitiveWallsFile = {
+  readonly lines: Vector3[][];
+  readonly material: PrimitiveWallsMaterial;
+};
+
+export function primitiveWallsFileParse(vrmlString: string): PrimitiveWallsFile {
+  let remainingVrml = vrmlString;
+
+  const expectedMagic = '#VRML V1.0 ascii';
+  if (!remainingVrml.startsWith(expectedMagic)) {
+    throw new Error(`unexpected WRL header: ${remainingVrml.slice(0, expectedMagic.length)}`);
+  }
+  remainingVrml = stripNextWhitespaceAndComments(
+    remainingVrml.slice(expectedMagic.length).trimStart()
+  );
+
+  // potentially skip the `DEF BackgroundColor`, if any.
+  remainingVrml = skipSimpleSection(remainingVrml).trim();
+
+  if (!remainingVrml.startsWith('# Vectors')) {
+    console.error('context', { remainingVrml });
+    throw new Error('Expected Vectors section but did not find it');
+  }
+  remainingVrml = stripNextWhitespaceAndComments(remainingVrml);
+
+  const { coordinates, remainder: coordsRemainder } = readCoordinate3(remainingVrml);
+  remainingVrml = coordsRemainder.trim();
+
+  const { material, remainder: matsRemainder } = readMaterial(remainingVrml);
+  remainingVrml = matsRemainder.trim();
+
+  const { indexValues, remainder } = readIndexedLineSet(remainingVrml);
+  remainingVrml = remainder.trim();
+
+  const lines = coordsAndLineSetToVertices(coordinates, indexValues);
+
+  return {
+    lines,
+    material,
+  };
+}
+
+function coordsAndLineSetToVertices(coordinates: Vector3[], indexValues: number[]) {
+  const lines: Vector3[][] = [];
+
+  let currentLine: Vector3[] = [];
+  for (const idx of indexValues) {
+    if (idx === -1) {
+      lines.push(currentLine);
+      currentLine = [];
+    } else {
+      const coord = coordinates[idx];
+      if (!coord) {
+        throw new Error(`Found idx=${idx} but no corresponding coordinate`);
+      }
+      currentLine.push(coord);
+    }
+  }
+
+  if (currentLine.length > 0) {
+    lines.push(currentLine);
+  }
+  return lines;
+}
+
+const leadingWhitespaceOrCommentRe = /^(?:\s*#[^\n]+\n|\s+)(.*)/s;
+
+function readMaterial(text: string) {
+  const bodyRe = /^Material +{\s+emissiveColor +(?<emissive>[\d\. ]+)\s+diffuseColor +(?<diffuse>[\d\. ]+)\s*\}(?<remainder>.*)/s;
+
+  const match = bodyRe.exec(text);
+  if (!match) {
+    console.error('context', { text });
+    throw new Error('Did not find Material as expected');
+  }
+
+  const { emissive, diffuse, remainder } = match.groups!;
+
+  return {
+    material: {
+      emissiveColor: rgbStringToColor(emissive),
+      diffuseColor: rgbStringToColor(diffuse),
+    } satisfies PrimitiveWallsMaterial,
+    remainder,
+  };
+}
+
+function rgbStringToColor(rgbStr: string) {
+  const colorCompos = rgbStr.trim().split(/ +/).map(component => Number(component));
+  if (colorCompos.length !== 3) {
+    console.error('context', { rgbStr, colorCompos });
+    throw new Error('Did not find 3 color components as expected');
+  }
+  const [r,g,b] = colorCompos;
+  return new Color(r,g,b);
+}
+
+function readCoordinate3(text: string) {
+  const bodyRe = /^Coordinate3 +{\s+point +\[\s+(?<points>[\d\.e\s,-]+)\]\s*\}(?<remainder>.*)/s;
+
+  const match = bodyRe.exec(text);
+  if (!match) {
+    console.error('context', { text });
+    throw new Error('Did not find Coordinate3 as expected');
+  }
+  const { points, remainder } = match.groups!;
+
+  const coordinates = points.trim().split(/\s*,\s*/gs).map(
+    (coordStr, i) => {
+      const parts = coordStr.split(/ +/g).map(part => Number(part));
+      if (parts.length !== 3) {
+        throw new Error(`Coordinate3 point index ${i} had ${parts.length} parts instead of 3`);
+      }
+      return new Vector3(...parts);
+    }
+  );
+
+  return {
+    coordinates,
+    remainder,
+  };
+}
+
+function readIndexedLineSet(text: string) {
+  const bodyRe = /^IndexedLineSet\s+{\s+coordIndex\s+\[\s+(?<indexes>[\d\s,-]+)\]\s*\}(?<remainder>.*)/s;
+
+  const match = bodyRe.exec(text);
+  if (!match) {
+    console.error('context', { text });
+    throw new Error('Did not find IndexedLineSet as expected');
+  }
+  const { indexes, remainder } = match.groups!;
+
+  const indexValues = indexes.trim().split(/\s*,\s*/gs).map(idx => Number(idx));
+
+  return {
+    indexValues,
+    remainder,
+  };
+}
+
+
+function skipSimpleSection(text: string) {
+  const defRe = /^(?:\s*\w+ +)+{[^}]+}(.*)/s;
+
+  const match = defRe.exec(text);
+  if (!match) {
+    return text;
+  }
+  return match[1];
+}
+
+function stripNextWhitespaceAndComments(text: string): string {
+  const reMatch = leadingWhitespaceOrCommentRe.exec(text);
+  if (!reMatch) {
+    return text;
+  }
+  return stripNextWhitespaceAndComments(reMatch[1]);
+}
+
+export function readNextSection(text: string) {
+  const result = /^\s*(\w+)/s.exec(text);
+  if (!result) {
+    throw new Error(`expected section start in ${JSON.stringify(text)}`);
+  }
+  return result[1];
+}

--- a/src/app/shared/models/model-type.enum.ts
+++ b/src/app/shared/models/model-type.enum.ts
@@ -8,4 +8,6 @@ export enum FileModelType {
   gLTF = 'gltf',
   /** CavernSeer ScanFile binary */
   cavernseerscan = 'cavernseerscan',
+  /** Walls */
+  walls = 'walls',
 }

--- a/src/app/shared/models/render/any-render-model.ts
+++ b/src/app/shared/models/render/any-render-model.ts
@@ -1,12 +1,14 @@
-import { CavernSeerScanRenderModel } from "./cavern-seer-scan.render-model";
-import type { GltfRenderModel } from "./gltf.render-model";
-import type { GroupRenderModel } from "./group.render-model";
-import type { ObjRenderModel } from "./obj.render-model";
-import type { UnknownRenderModel } from "./unknown.render-model";
+import type { CavernSeerScanRenderModel } from './cavern-seer-scan.render-model';
+import type { GltfRenderModel } from './gltf.render-model';
+import type { GroupRenderModel } from './group.render-model';
+import type { ObjRenderModel } from './obj.render-model';
+import type { UnknownRenderModel } from './unknown.render-model';
+import type { WallsRenderModel } from './walls.render-model';
 
 export type AnyRenderModel =
   | GltfRenderModel
   | GroupRenderModel
   | ObjRenderModel
   | CavernSeerScanRenderModel
+  | WallsRenderModel
   | UnknownRenderModel;

--- a/src/app/shared/models/render/walls.render-model.ts
+++ b/src/app/shared/models/render/walls.render-model.ts
@@ -1,0 +1,141 @@
+import {BaseVisibleRenderModel} from "./base.render-model";
+import {FileModelType} from "../model-type.enum";
+import {Subject} from "rxjs";
+import {ModelChangeType} from "../model-change-type.enum";
+import {BufferGeometry, Group, Line, LineBasicMaterial, Mesh, Object3DEventMap} from "three";
+import {BaseAnnotation} from "../annotations/base.annotation";
+import {IMapperUserData} from "../user-data";
+import {BaseMaterialService} from "../../services/3d-managers/base-material.service";
+import {ISimpleVector3} from "../simple-types";
+import {markSceneOfItemForReRender} from "../../functions/mark-scene-of-item-for-rerender";
+import {UploadFileModel} from "../upload-file-model";
+import {PrimitiveWallsFile} from "../../functions/primitiveWallsFileParse";
+
+export class WallsRenderModel extends BaseVisibleRenderModel<FileModelType.walls> {
+  override readonly type = FileModelType.walls;
+  readonly #childOrPropertyChanged = new Subject<ModelChangeType>();
+  override readonly childOrPropertyChanged$ = this.#childOrPropertyChanged.asObservable();
+  override readonly identifier: string;
+  override comment: string | null;
+  override readonly rendered = true;
+
+  override get position() {
+    return this.#group.position;
+  }
+  override get visible() {
+    return this.#group.visible;
+  }
+
+  readonly #blob: Blob;
+  readonly #walls: PrimitiveWallsFile;
+  readonly #group: Group;
+  readonly #annotations = new Set<BaseAnnotation>();
+
+  constructor(
+    identifier: string,
+    walls: PrimitiveWallsFile,
+    blob: Blob,
+    comment: string | null,
+  ) {
+    super();
+
+    this.identifier = identifier;
+    this.comment = comment;
+    this.#blob = blob;
+
+    this.#walls = walls;
+    this.#group = new Group();
+    this.#group.add(...WallsRenderModel.vectorsToLines(walls));
+    this.#group.rotateX(-Math.PI / 2);
+
+    (this.#group.userData as IMapperUserData).fromSerializedModel = true;
+    // don't traverse all items, don't mark all sub-items as fromSerializedModel
+  }
+
+  static fromUploadModelAndParsedScanFile(uploadModel: UploadFileModel, walls: PrimitiveWallsFile) {
+    const { identifier, blob, comment } = uploadModel;
+    return new WallsRenderModel(
+      identifier,
+      walls,
+      blob,
+      comment,
+    );
+  }
+
+  static vectorsToLines(walls: PrimitiveWallsFile) {
+    const mat = new LineBasicMaterial({
+      color: walls.material.diffuseColor,
+    });
+
+    return walls.lines.map(vectorOfLine => {
+      const geo = new BufferGeometry().setFromPoints(
+        vectorOfLine,
+      );
+      return new Line(geo, mat);
+    });
+  }
+
+  override getAnnotations(): readonly BaseAnnotation[] {
+    return [...this.#annotations];
+  }
+  override addAnnotation(anno: BaseAnnotation, toGroup?: Group<Object3DEventMap> | undefined): boolean {
+    if (toGroup && this.#group !== toGroup) {
+      return false;
+    }
+
+    anno.addToGroup(this.#group);
+    this.#annotations.add(anno);
+    this.#childOrPropertyChanged.next(ModelChangeType.EntityAdded);
+    return true;
+  }
+  override removeAnnotations(annosToDelete: Set<BaseAnnotation>): void {
+    for (const anno of annosToDelete) {
+
+      const deleted = this.#annotations.delete(anno);
+      if (!deleted) {
+        continue;
+      }
+
+      anno.removeFromGroup(this.#group);
+      this.#childOrPropertyChanged.next(ModelChangeType.EntityRemoved);
+
+      annosToDelete.delete(anno);
+    }
+  }
+  override setMaterial(material: BaseMaterialService<any>): void {
+    this.#group.traverse(child => {
+      if (child instanceof Mesh && (child.userData as IMapperUserData).fromSerializedModel) {
+        child.material = material.material;
+      }
+    });
+  }
+  override setPosition({ x, y, z }: ISimpleVector3): boolean {
+    this.#group.position.set(x, y, z);
+    this.#childOrPropertyChanged.next(ModelChangeType.PositionChanged);
+    markSceneOfItemForReRender(this.#group);
+    return true;
+  }
+  override setVisibility(visible: boolean): void {
+    this.#group.visible = visible;
+    markSceneOfItemForReRender(this.#group);
+  }
+  override setComment(comment: string | null): boolean {
+    this.comment = comment;
+    return true;
+  }
+  override serialize(): Blob | null {
+    return this.#blob;
+  }
+  override addToGroup(group: Group<Object3DEventMap>): void {
+    if (this.#group.parent !== null) {
+      throw new Error('attempt to add WallsRenderModel to group while model already has a parent');
+    }
+    group.add(this.#group);
+  }
+  override removeFromGroup(group: Group<Object3DEventMap>): void {
+    group.remove(this.#group);
+  }
+  override dispose(): void {
+    // dispose
+  }
+}

--- a/src/app/shared/models/render/walls.render-model.ts
+++ b/src/app/shared/models/render/walls.render-model.ts
@@ -1,15 +1,15 @@
-import {BaseVisibleRenderModel} from "./base.render-model";
-import {FileModelType} from "../model-type.enum";
-import {Subject} from "rxjs";
-import {ModelChangeType} from "../model-change-type.enum";
-import {BufferGeometry, Group, Line, LineBasicMaterial, Mesh, Object3DEventMap} from "three";
-import {BaseAnnotation} from "../annotations/base.annotation";
-import {IMapperUserData} from "../user-data";
-import {BaseMaterialService} from "../../services/3d-managers/base-material.service";
-import {ISimpleVector3} from "../simple-types";
-import {markSceneOfItemForReRender} from "../../functions/mark-scene-of-item-for-rerender";
-import {UploadFileModel} from "../upload-file-model";
-import {PrimitiveWallsFile} from "../../functions/primitiveWallsFileParse";
+import { BaseVisibleRenderModel } from './base.render-model';
+import { FileModelType } from '../model-type.enum';
+import { Subject } from 'rxjs';
+import { ModelChangeType } from '../model-change-type.enum';
+import { BufferGeometry, Group, Line, LineBasicMaterial, Mesh, Object3DEventMap } from 'three';
+import { BaseAnnotation } from '../annotations/base.annotation';
+import { IMapperUserData } from '../user-data';
+import { BaseMaterialService } from '../../services/3d-managers/base-material.service';
+import { ISimpleVector3 } from '../simple-types';
+import { markSceneOfItemForReRender } from '../../functions/mark-scene-of-item-for-rerender';
+import { UploadFileModel } from '../upload-file-model';
+import { PrimitiveWallsFile } from '../../functions/primitiveWallsFileParse';
 
 export class WallsRenderModel extends BaseVisibleRenderModel<FileModelType.walls> {
   override readonly type = FileModelType.walls;

--- a/src/app/shared/services/file-type.service.ts
+++ b/src/app/shared/services/file-type.service.ts
@@ -33,6 +33,9 @@ export class FileTypeService {
     if (this.isCavernSeerScan(mime, name)) {
       return FileModelType.cavernseerscan;
     }
+    if (this.isVrmlFile(mime, name)) {
+      return FileModelType.walls;
+    }
     return FileModelType.unknown;
   }
 
@@ -71,5 +74,9 @@ export class FileTypeService {
 
   isCavernSeerScan(mime: string, name: string) {
     return mime === 'application/vnd.org.grush.cavernseer.scan' || this.getFileExtension(name) === '.cavernseerscan';
+  }
+
+  isVrmlFile(mime: string, name: string) {
+    return mime === 'model/vrml' || this.getFileExtension(name) === '.wrl';
   }
 }


### PR DESCRIPTION
Goals:
- [x] Allow importing very simple [Walls](https://github.com/wallscavesurvey/walls/tree/95b328b39988b0fa2e4fb50e304c3f3b47c9ee71) file outputs; NOT targetting ALL `.wrl` files, just Walls files

Changes:
* implemented `primitiveWallsFileParse()` which parses the output of Walls' WRL files extremely primitively, only reading the first coordinates, material, and lines
* Adds WallsRenderModel 

Unrelated changes:
* in sidenav, put the packageVersion instead of version into URL