### PR TITLE
SVG Export and 3D Model Exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavern-seer-mapper",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "homepage": "https://github.com/skgrush/cavern-seer-mapper#readme",
   "license": "MIT",
   "author": {

--- a/src/app/deferred.routes.ts
+++ b/src/app/deferred.routes.ts
@@ -19,6 +19,7 @@ import { provideSettings } from "./shared/services/settings";
 import { ThemeService } from "./shared/services/theme.service";
 import { ToolManagerService } from "./shared/services/tool-manager.service";
 import { toolsProviders } from "./shared/services/tools";
+import { MeshStandardMaterialService } from './shared/services/3d-managers/mesh-standard-material.service';
 
 const deferredRoutes: Routes = [
   {
@@ -52,6 +53,7 @@ const deferredRoutes: Routes = [
       ModelLoadService,
       ModelManagerService,
       MeshNormalMaterialService,
+      MeshStandardMaterialService,
       ToolManagerService,
       AnnotationBuilderService,
       DialogOpenerService,

--- a/src/app/dialogs/export-image-dialog/export-image-dialog.component.html
+++ b/src/app/dialogs/export-image-dialog/export-image-dialog.component.html
@@ -14,9 +14,15 @@
           <mat-button-toggle [value]="fileType">{{ fileType }}</mat-button-toggle>
           }
         </mat-button-toggle-group>
+        <p *ngIf="formGroup.controls.type.value === 'webp'">
+          Web
+        </p>
+        <p *ngIf="formGroup.controls.type.value === 'svg'">
+          This is not recommended and will generate massive SVG files but go off.
+        </p>
       </section>
 
-      <section>
+      <section *ngIf="selectedTypeIsScalable">
         <h4>Scale factor</h4>
         <mat-button-toggle-group [formControl]="formGroup.controls.scaleFactor">
           @for(scaleFactor of scaleFactors; track scaleFactors) {

--- a/src/app/dialogs/export-image-dialog/export-image-dialog.component.html
+++ b/src/app/dialogs/export-image-dialog/export-image-dialog.component.html
@@ -15,7 +15,7 @@
           }
         </mat-button-toggle-group>
         <p *ngIf="formGroup.controls.type.value === 'webp'">
-          Web
+          WebP is not supported and all browsers and may fall back to JPG.
         </p>
         <p *ngIf="formGroup.controls.type.value === 'svg'">
           This is not recommended and will generate massive SVG files but go off.

--- a/src/app/dialogs/export-image-dialog/export-image-dialog.component.ts
+++ b/src/app/dialogs/export-image-dialog/export-image-dialog.component.ts
@@ -44,7 +44,11 @@ export class ExportImageDialogComponent {
     return dimensions.clone().multiplyScalar(scaleFactor);
   }
 
-  readonly fileTypes = ['jpeg', 'png', 'webp'] as const;
+  get selectedTypeIsScalable() {
+    return this.formGroup.controls.type.value !== 'svg';
+  }
+
+  readonly fileTypes = ['jpeg', 'png', 'webp', 'svg'] as const;
   readonly scaleFactors = [1, 2, 4, 8, 16, 32] as const;
 
   readonly resultSubject = new BehaviorSubject<{
@@ -91,13 +95,17 @@ export class ExportImageDialogComponent {
 
     const { fileName, scaleFactor, type } = this.formGroup.getRawValue();
 
-    this.#exportService.downloadCanvasImage$(
-      fileName,
-      type,
-      rendererSymbol,
-      camera,
-      scaleFactor,
-    ).pipe(
+    const obs$ = type === 'svg'
+      ? this.#exportService.downloadCanvasSvg$(fileName, rendererSymbol, camera)
+      : this.#exportService.downloadCanvasImage$(
+          fileName,
+          type,
+          rendererSymbol,
+          camera,
+          scaleFactor,
+        );
+
+    obs$.pipe(
       tap({
         finalize: () => {
           this.formGroup.enable();

--- a/src/app/dialogs/export-image-dialog/export-image-dialog.component.ts
+++ b/src/app/dialogs/export-image-dialog/export-image-dialog.component.ts
@@ -110,9 +110,7 @@ export class ExportImageDialogComponent {
         finalize: () => {
           this.formGroup.enable();
           this.#dialogRef.disableClose = false;
-        }
-      }),
-      tap({
+        },
         next: result => this.resultSubject.next(result),
         error: err => this.errorSubject.next(err),
       }),

--- a/src/app/dialogs/export-model-dialog/export-model-dialog.component.html
+++ b/src/app/dialogs/export-model-dialog/export-model-dialog.component.html
@@ -1,0 +1,33 @@
+<form (submit)="submit($event)">
+  <h1 mat-dialog-title>{{ titleText }}</h1>
+  <div mat-dialog-content>
+    <div class="form-fields-grid">
+      <mat-form-field>
+        <mat-label>File name</mat-label>
+        <input matInput type="text" [formControl]="formGroup.controls.fileName">
+      </mat-form-field>
+
+      <section>
+        <h4>File type</h4>
+        <mat-button-toggle-group [formControl]="formGroup.controls.type">
+          @for(fileType of modelExporterNames; track fileType) {
+            <mat-button-toggle [value]="fileType">{{ fileType }}</mat-button-toggle>
+          }
+        </mat-button-toggle-group>
+      </section>
+    </div>
+
+    <div *ngIf="resultSubject | async as result">
+      Successfully exported {{ result.name }} at {{ result.size | bytes }}.
+    </div>
+
+    <div mat-dialog-actions>
+      <button type="button" mat-button mat-dialog-close cdkFocusInitial>
+        Cancel
+      </button>
+      <button type="submit" mat-button [disabled]="!formGroup.valid">
+        Export
+      </button>
+    </div>
+  </div>
+</form>

--- a/src/app/dialogs/export-model-dialog/export-model-dialog.component.html
+++ b/src/app/dialogs/export-model-dialog/export-model-dialog.component.html
@@ -14,6 +14,37 @@
             <mat-button-toggle [value]="fileType">{{ fileType }}</mat-button-toggle>
           }
         </mat-button-toggle-group>
+
+        <p *ngIf="wikiLink as link">
+          <a [href]="link" target="_blank">Wikipedia Link</a>
+        </p>
+        <ng-container [ngSwitch]="formGroup.controls.type.value">
+          <p *ngSwitchCase="ModelExporterNames.OBJ">
+            OBJ is the most widely supported format by almost all viewers (e.g. Windows and macOS viewers),
+            but also one of the least space efficient.
+          </p>
+          <p *ngSwitchCase="ModelExporterNames.GLTF">
+            gLTF is supported by many modeling systems; less-space-efficient version of GLB.
+          </p>
+          <p *ngSwitchCase="ModelExporterNames.GLB">
+            gLTF-binary is supported by many modeling systems; more-space-efficient version of gLTF.
+          </p>
+          <p *ngSwitchCase="ModelExporterNames.STL">
+            STL is a CAD modeling format supported by many systems.
+            It seems to be one of the <b>least-space-efficient</b> binary formats for CavernSeer.
+          </p>
+          <p *ngSwitchCase="ModelExporterNames.PLY">
+            PLY is a format for storing polygonal data.
+            It seems to be the <b>most-space-efficient</b> binary format for CavernSeer.
+          </p>
+          <p *ngSwitchCase="ModelExporterNames.USDZ">
+            <em>Currently unsupported by CavernSeer Mapper; seems to export empty files.</em>
+          </p>
+        </ng-container>
+
+        <p class="ascii-warning" *ngIf="modelExporterAsciis.has(formGroup.controls.type.value)">
+          This format is a plaintext/ASCII format, which can create excessively large, or even un-exportable, files.
+        </p>
       </section>
     </div>
 

--- a/src/app/dialogs/export-model-dialog/export-model-dialog.component.scss
+++ b/src/app/dialogs/export-model-dialog/export-model-dialog.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/dialogs/export-model-dialog/export-model-dialog.component.scss
+++ b/src/app/dialogs/export-model-dialog/export-model-dialog.component.scss
@@ -1,3 +1,7 @@
 :host {
   display: block;
 }
+
+.ascii-warning {
+  font-weight: bold;
+}

--- a/src/app/dialogs/export-model-dialog/export-model-dialog.component.spec.ts
+++ b/src/app/dialogs/export-model-dialog/export-model-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExportModelDialogComponent } from './export-model-dialog.component';
+
+describe('ExportModelDialogComponent', () => {
+  let component: ExportModelDialogComponent;
+  let fixture: ComponentFixture<ExportModelDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ExportModelDialogComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(ExportModelDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dialogs/export-model-dialog/export-model-dialog.component.ts
+++ b/src/app/dialogs/export-model-dialog/export-model-dialog.component.ts
@@ -1,9 +1,10 @@
 import { ChangeDetectionStrategy, Component, inject, Injector } from '@angular/core';
-import { ExportService, ModelExporterNames } from '../../shared/services/export.service';
+import { ExportService, modelExporterAsciis, ModelExporterNames } from '../../shared/services/export.service';
 import {
   MAT_DIALOG_DATA,
   MatDialog,
-  MatDialogActions, MatDialogClose,
+  MatDialogActions,
+  MatDialogClose,
   MatDialogContent,
   MatDialogRef,
   MatDialogTitle,
@@ -13,7 +14,7 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatButtonToggle, MatButtonToggleGroup } from '@angular/material/button-toggle';
-import { AsyncPipe, NgIf } from '@angular/common';
+import { AsyncPipe, NgIf, NgSwitch, NgSwitchCase } from '@angular/common';
 import { BytesPipe } from '../../shared/pipes/bytes.pipe';
 import { MatButton } from '@angular/material/button';
 
@@ -39,6 +40,8 @@ export type IExportModelDialogData = {
     MatButton,
     MatDialogActions,
     MatDialogClose,
+    NgSwitch,
+    NgSwitchCase,
   ],
   templateUrl: './export-model-dialog.component.html',
   styleUrl: './export-model-dialog.component.scss',
@@ -47,6 +50,7 @@ export type IExportModelDialogData = {
 export class ExportModelDialogComponent {
   readonly ModelExporterNames = ModelExporterNames;
   readonly modelExporterNames = Object.values(ModelExporterNames);
+  readonly modelExporterAsciis: Set<ModelExporterNames | null> = modelExporterAsciis;
 
   readonly #exportService = inject(ExportService);
   readonly #dialogRef = inject<MatDialogRef<ExportModelDialogComponent, boolean>>(MatDialogRef);
@@ -64,6 +68,28 @@ export class ExportModelDialogComponent {
     fileName: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
     type: new FormControl<ModelExporterNames | null>(null, { validators: [Validators.required] }),
   });
+
+  get wikiLink() {
+    const type = this.formGroup.controls.type.value;
+
+    const wikiBase = 'https://en.wikipedia.org/wiki/';
+    switch (type) {
+      case ModelExporterNames.STL:
+      case ModelExporterNames.STLAscii:
+        return `${wikiBase}STL_(file_format)`;
+      case ModelExporterNames.PLY:
+      case ModelExporterNames.PLYAscii:
+        return `${wikiBase}PLY_(file_format)`;
+      case ModelExporterNames.OBJ:
+        return `${wikiBase}Wavefront_.obj_file`;
+      case ModelExporterNames.GLTF:
+      case ModelExporterNames.GLB:
+        return `${wikiBase}GlTF`;
+      case ModelExporterNames.USDZ:
+        return `${wikiBase}Universal_Scene_Description`;
+    }
+    return null;
+  }
 
   static open(
     dialog: MatDialog,

--- a/src/app/dialogs/export-model-dialog/export-model-dialog.component.ts
+++ b/src/app/dialogs/export-model-dialog/export-model-dialog.component.ts
@@ -1,0 +1,106 @@
+import { ChangeDetectionStrategy, Component, inject, Injector } from '@angular/core';
+import { ExportService, ModelExporterNames } from '../../shared/services/export.service';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogActions, MatDialogClose,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import { BehaviorSubject, tap } from 'rxjs';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { MatButtonToggle, MatButtonToggleGroup } from '@angular/material/button-toggle';
+import { AsyncPipe, NgIf } from '@angular/common';
+import { BytesPipe } from '../../shared/pipes/bytes.pipe';
+import { MatButton } from '@angular/material/button';
+
+export type IExportModelDialogData = {
+  readonly titleText: string;
+}
+
+@Component({
+  selector: 'mapper-export-model-dialog',
+  standalone: true,
+  imports: [
+    MatDialogContent,
+    MatDialogTitle,
+    ReactiveFormsModule,
+    MatFormField,
+    MatInput,
+    MatLabel,
+    MatButtonToggle,
+    MatButtonToggleGroup,
+    NgIf,
+    AsyncPipe,
+    BytesPipe,
+    MatButton,
+    MatDialogActions,
+    MatDialogClose,
+  ],
+  templateUrl: './export-model-dialog.component.html',
+  styleUrl: './export-model-dialog.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ExportModelDialogComponent {
+  readonly ModelExporterNames = ModelExporterNames;
+  readonly modelExporterNames = Object.values(ModelExporterNames);
+
+  readonly #exportService = inject(ExportService);
+  readonly #dialogRef = inject<MatDialogRef<ExportModelDialogComponent, boolean>>(MatDialogRef);
+  readonly #dialogData: IExportModelDialogData = inject(MAT_DIALOG_DATA);
+
+  readonly titleText = this.#dialogData.titleText;
+
+  readonly resultSubject = new BehaviorSubject<{
+    name: string,
+    size: number,
+  } | undefined>(undefined);
+  readonly errorSubject = new BehaviorSubject<any | undefined>(undefined);
+
+  readonly formGroup = new FormGroup({
+    fileName: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    type: new FormControl<ModelExporterNames | null>(null, { validators: [Validators.required] }),
+  });
+
+  static open(
+    dialog: MatDialog,
+    injector: Injector,
+    data: IExportModelDialogData,
+  ) {
+    return dialog.open<ExportModelDialogComponent, IExportModelDialogData>(
+      ExportModelDialogComponent,
+      {
+        data,
+        injector,
+      },
+    );
+  }
+
+  submit(event: SubmitEvent) {
+    event.preventDefault();
+
+    if (!this.formGroup.valid || !this.formGroup.enabled) {
+      return;
+    }
+
+    this.formGroup.disable();
+    this.resultSubject.next(undefined);
+    this.#dialogRef.disableClose = true;
+
+    const { fileName, type } = this.formGroup.getRawValue();
+
+    this.#exportService.downloadModel$(fileName, type!).pipe(
+      tap({
+        finalize: () => {
+          this.formGroup.enable();
+          this.#dialogRef.disableClose = false;
+        },
+        next: result => this.resultSubject.next(result),
+        error: err => this.errorSubject.next(err),
+      }),
+    ).subscribe();
+  }
+}

--- a/src/app/pages/sidenav/sidenav.component.html
+++ b/src/app/pages/sidenav/sidenav.component.html
@@ -3,6 +3,7 @@
   <button mat-list-item (click)="dialogOpener.import()">Import...</button>
   <button mat-list-item (click)="dialogOpener.save()">Zip...</button>
   <button mat-list-item (click)="dialogOpener.exportImage()">Export image...</button>
+  <button mat-list-item (click)="dialogOpener.exportModel()">Export model...</button>
   <button mat-list-item (click)="dialogOpener.settings()">Settings</button>
   <button mat-list-item (click)="checkForUpdate()">Check for update</button>
 </mat-list>

--- a/src/app/shared/models/render/group.render-model.ts
+++ b/src/app/shared/models/render/group.render-model.ts
@@ -1,5 +1,5 @@
 import { Subject, Subscription } from "rxjs";
-import { BoxHelper, Group, Object3DEventMap, Scene } from "three";
+import { BoxHelper, Group, Object3D, Object3DEventMap, Scene } from 'three';
 import { markSceneOfItemForReRender } from "../../functions/mark-scene-of-item-for-rerender";
 import { BaseMaterialService } from "../../services/3d-managers/base-material.service";
 import { BaseAnnotation } from "../annotations/base.annotation";
@@ -112,6 +112,10 @@ export class GroupRenderModel extends BaseVisibleRenderModel<FileModelType.group
     const box = boxHelper.geometry.boundingBox!;
     boxHelper.dispose();
     return box;
+  }
+
+  encode<T>(fn: (o: Object3D) => T) {
+    return fn(this.#group);
   }
 
   dispose() {

--- a/src/app/shared/services/3d-managers/mesh-normal-material.service.ts
+++ b/src/app/shared/services/3d-managers/mesh-normal-material.service.ts
@@ -1,15 +1,8 @@
 import { Injectable } from '@angular/core';
-import { Color, MeshNormalMaterial } from 'three';
+import { MeshNormalMaterial } from 'three';
 import { BaseMaterialService } from './base-material.service';
 
 @Injectable()
 export class MeshNormalMaterialService extends BaseMaterialService<MeshNormalMaterial> {
-  override material: MeshNormalMaterial;
-
-
-  constructor() {
-    super();
-    this.material = new MeshNormalMaterial();
-    (this.material as any).color = new Color(0, 0, 0);
-  }
+  override readonly material = new MeshNormalMaterial();
 }

--- a/src/app/shared/services/3d-managers/mesh-normal-material.service.ts
+++ b/src/app/shared/services/3d-managers/mesh-normal-material.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { MeshNormalMaterial } from 'three';
+import { Color, MeshNormalMaterial } from 'three';
 import { BaseMaterialService } from './base-material.service';
 
 @Injectable()
@@ -10,5 +10,6 @@ export class MeshNormalMaterialService extends BaseMaterialService<MeshNormalMat
   constructor() {
     super();
     this.material = new MeshNormalMaterial();
+    (this.material as any).color = new Color(0, 0, 0);
   }
 }

--- a/src/app/shared/services/3d-managers/mesh-standard-material.service.ts
+++ b/src/app/shared/services/3d-managers/mesh-standard-material.service.ts
@@ -1,0 +1,13 @@
+import { BaseMaterialService } from './base-material.service';
+import { MeshStandardMaterial } from 'three';
+
+/**
+ * Requires a directional light.
+ */
+export class MeshStandardMaterialService extends BaseMaterialService<MeshStandardMaterial> {
+  override readonly material = new MeshStandardMaterial({
+    color: 0xCCCCCC,
+    metalness: 0.2,
+    flatShading: true,
+  });
+}

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -30,7 +30,7 @@ import { MeshNormalMaterialService } from './3d-managers/mesh-normal-material.se
 import { LocalizeService } from './localize.service';
 import { ModelManagerService } from './model-manager.service';
 import {SettingsService} from "./settings/settings.service";
-import { SVGRenderer } from 'three/examples/jsm/renderers/SVGRenderer';
+import { SVGRenderer } from 'three/examples/jsm/renderers/SVGRenderer.js';
 
 @Injectable()
 export class CanvasService {

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -203,6 +203,10 @@ export class CanvasService {
     markSceneOfItemForReRender(this.#scene);
   }
 
+  /**
+   * When observed, switch to the requested material.
+   * When unsubscribed, switch back to the original material.
+   */
   temporarilySwitchMaterial$(to: keyof CanvasService['materials']) {
     return new Observable<void>(subscriber => {
       const oldMaterialService = this.#material;

--- a/src/app/shared/services/dialog-opener.service.ts
+++ b/src/app/shared/services/dialog-opener.service.ts
@@ -81,4 +81,17 @@ export class DialogOpenerService {
         );
       });
   }
+
+  exportModel() {
+    import('../../dialogs/export-model-dialog/export-model-dialog.component')
+      .then(({ ExportModelDialogComponent }) => {
+        ExportModelDialogComponent.open(
+          this.#dialog,
+          this.#injector,
+          {
+            titleText: 'Export model',
+          },
+        )
+      });
+  }
 }

--- a/src/app/shared/services/export.service.ts
+++ b/src/app/shared/services/export.service.ts
@@ -57,7 +57,8 @@ export class ExportService {
   }
 
   downloadCanvasImage$(
-    baseName: string, ext: 'png' | 'jpeg' | 'webp',
+    baseName: string,
+    ext: 'png' | 'jpeg' | 'webp',
     rendererSymbol?: symbol,
     camera?: Camera,
     sizeMultiplier?: number,
@@ -77,6 +78,24 @@ export class ExportService {
         );
       }),
     );
+  }
+
+  downloadCanvasSvg$(
+    baseName: string,
+    rendererSymbol?: symbol,
+    camera?: Camera,
+  ) {
+    return defer(() => {
+      const { blob, renderInfo } = this.#canvasService.exportToSvg(rendererSymbol, camera);
+
+      const name = this.normalizeName(null, baseName, '.svg');
+      const size = blob.size;
+      console.info('Download SVG context:', { name, size, renderInfo });
+
+      return this.downloadBlob$(name, blob).pipe(
+        map(() => ({ name, size, renderInfo })),
+      );
+    });
   }
 
   downloadBlob$(filename: string, blob: Blob) {

--- a/src/app/shared/services/export.service.ts
+++ b/src/app/shared/services/export.service.ts
@@ -19,6 +19,13 @@ export enum ModelExporterNames {
   USDZ = 'USDZ',
 }
 
+export const modelExporterAsciis = new Set([
+  ModelExporterNames.OBJ,
+  ModelExporterNames.GLTF,
+  ModelExporterNames.PLYAscii,
+  ModelExporterNames.STLAscii,
+] as const);
+
 const modelExporterExtensions = {
   OBJ: ['obj', 'model/obj'],
   GLTF: ['gltf', 'model/gltf+json'],
@@ -80,7 +87,7 @@ export class ExportService {
       map(({ STLExporter }) => new STLExporter().parse(model, { binary: false })),
     ),
     USDZ: (model: Object3D) => defer(() => import('three/examples/jsm/exporters/USDZExporter.js')).pipe(
-      map(({ USDZExporter }) => new USDZExporter().parse(model)),
+      map(({ USDZExporter }) => new USDZExporter().parse(model, { quickLookCompatible: true })),
     ),
   } satisfies Record<ModelExporterNames, any>;
 


### PR DESCRIPTION
Version 0.3.5.

Core changes:
* SVG image exporter; not very efficient but pretty cool
* 3D Model exporters (closes #38)
   - OBJ
   - GLTF + GLB
   - PLY (binary and ascii)
   - STL (binary and ascii)
   - USDZ **(not currently working for some reason, followup in #40)**

Side-effect changes:
* `CanvasService` allows changing materials; not yet exposed to user
   - used internally by model exporters which get mad if we try to export with MeshNormalMaterial
* Added directional light