### PR TITLE
Fix USDZ and allow compressing all model exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavern-seer-mapper",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "homepage": "https://github.com/skgrush/cavern-seer-mapper#readme",
   "license": "MIT",
   "author": {

--- a/src/app/deferred.routes.ts
+++ b/src/app/deferred.routes.ts
@@ -20,6 +20,7 @@ import { ThemeService } from "./shared/services/theme.service";
 import { ToolManagerService } from "./shared/services/tool-manager.service";
 import { toolsProviders } from "./shared/services/tools";
 import { MeshStandardMaterialService } from './shared/services/3d-managers/mesh-standard-material.service';
+import { CompressionService } from './shared/services/compression.service';
 
 const deferredRoutes: Routes = [
   {
@@ -46,6 +47,7 @@ const deferredRoutes: Routes = [
       CanvasService,
       ResizeService,
       ExportService,
+      CompressionService,
       ThemeService,
       importProvidersFrom(FileIconModule),
       FileTypeService,

--- a/src/app/dialogs/export-model-dialog/export-model-dialog.component.html
+++ b/src/app/dialogs/export-model-dialog/export-model-dialog.component.html
@@ -50,6 +50,10 @@
           This format is a plaintext/ASCII format, which can create excessively large, or even un-exportable, files.
         </p>
       </section>
+
+      <section>
+        <mat-checkbox [formControl]="formGroup.controls.compress">GZip compress</mat-checkbox>
+      </section>
     </div>
 
     <div *ngIf="resultSubject | async as result">

--- a/src/app/dialogs/export-model-dialog/export-model-dialog.component.html
+++ b/src/app/dialogs/export-model-dialog/export-model-dialog.component.html
@@ -25,20 +25,24 @@
           </p>
           <p *ngSwitchCase="ModelExporterNames.GLTF">
             gLTF is supported by many modeling systems; less-space-efficient version of GLB.
+            Supported by Windows 3D viewer.
           </p>
           <p *ngSwitchCase="ModelExporterNames.GLB">
             gLTF-binary is supported by many modeling systems; more-space-efficient version of gLTF.
+            Supported by Windows 3D viewer.
           </p>
           <p *ngSwitchCase="ModelExporterNames.STL">
             STL is a CAD modeling format supported by many systems.
             It seems to be one of the <b>least-space-efficient</b> binary formats for CavernSeer.
+            Supported by Windows and macOS 3D viewers.
           </p>
           <p *ngSwitchCase="ModelExporterNames.PLY">
             PLY is a format for storing polygonal data.
             It seems to be the <b>most-space-efficient</b> binary format for CavernSeer.
+            Supported by Windows 3D viewer.
           </p>
           <p *ngSwitchCase="ModelExporterNames.USDZ">
-            <em>Currently unsupported by CavernSeer Mapper; seems to export empty files.</em>
+            USD is a format for 3D graphics designers, but with limited viewer support.
           </p>
         </ng-container>
 

--- a/src/app/dialogs/export-model-dialog/export-model-dialog.component.html
+++ b/src/app/dialogs/export-model-dialog/export-model-dialog.component.html
@@ -32,22 +32,25 @@
             Supported by Windows 3D viewer.
           </p>
           <p *ngSwitchCase="ModelExporterNames.STL">
-            STL is a CAD modeling format supported by many systems.
+            STL is a CAD modeling format supported by many systems.<br/>
             It seems to be one of the <b>least-space-efficient</b> binary formats for CavernSeer.
             Supported by Windows and macOS 3D viewers.
           </p>
           <p *ngSwitchCase="ModelExporterNames.PLY">
-            PLY is a format for storing polygonal data.
+            PLY is a format for storing polygonal data.<br/>
             It seems to be the <b>most-space-efficient</b> binary format for CavernSeer.
             Supported by Windows 3D viewer.
           </p>
           <p *ngSwitchCase="ModelExporterNames.USDZ">
-            USD is a format for 3D graphics designers, but with limited viewer support.
+            USD is a format for 3D graphics designers, but with limited viewer support.<br>
+            It is the <b>least-space-efficient</b> when un-compressed, but when compressed
+            is nearly as small as PLY compressed.
           </p>
         </ng-container>
 
         <p class="ascii-warning" *ngIf="modelExporterAsciis.has(formGroup.controls.type.value)">
-          This format is a plaintext/ASCII format, which can create excessively large, or even un-exportable, files.
+          This format is a plaintext/ASCII format, which can create excessively large, or even un-exportable, files.<br/>
+          It is highly recommended to compress any ASCII format.
         </p>
       </section>
 

--- a/src/app/shared/services/compression.service.ts
+++ b/src/app/shared/services/compression.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { defer, from, tap } from 'rxjs';
+
+@Injectable()
+export class CompressionService {
+
+  compressOrDecompressBlob$(compress: boolean, blob: Blob, format: CompressionFormat, ) {
+    return defer(() => {
+      const abortController = new AbortController();
+
+      let pipedStream = blob.stream()
+        .pipeThrough(
+          compress ? new CompressionStream(format) : new DecompressionStream(format),
+          {
+            signal: abortController.signal,
+          },
+        );
+
+      pipedStream = pipedStream.pipeThrough(
+        new ByteLoggerStream(bytes => console.info(bytes)),
+      );
+
+      return from(
+        new Response(pipedStream).blob()
+      ).pipe(
+        tap({
+          unsubscribe: () => abortController.abort('unsubscribed'),
+        }),
+      );
+    });
+  }
+}
+
+
+class ByteLoggerStream extends TransformStream<Uint8Array, Uint8Array> {
+  constructor(cb: (bytes: number) => void) {
+    super({
+      start() { },
+      async transform(chunk, controller) {
+        cb(chunk.length);
+
+        controller.enqueue(chunk);
+      }
+    });
+  }
+}

--- a/src/app/shared/services/export.service.ts
+++ b/src/app/shared/services/export.service.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Injectable, inject, Type } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { defer, first, map, Observable, of, switchMap, take, tap, timer } from 'rxjs';
 import { ModelManagerService } from './model-manager.service';
 import { ModelLoadService } from './model-load.service';
@@ -7,6 +7,7 @@ import { TransportProgressHandler } from '../models/transport-progress-handler';
 import { CanvasService } from './canvas.service';
 import { Camera, Object3D } from 'three';
 import { ignoreNullish } from '../operators/ignore-nullish';
+import { CompressionService } from './compression.service';
 
 export enum ModelExporterNames {
   OBJ = 'OBJ',
@@ -55,10 +56,12 @@ export class ExportService {
   readonly #modelManager = inject(ModelManagerService);
   readonly #modelLoad = inject(ModelLoadService);
   readonly #canvasService = inject(CanvasService);
+  readonly #compressionService = inject(CompressionService);
 
   readonly #gltfModule = defer(() => import('three/examples/jsm/exporters/GLTFExporter.js'));
   readonly #plyModule = defer(() => import('three/examples/jsm/exporters/PLYExporter.js'));
   readonly #stlModule = defer(() => import('three/examples/jsm/exporters/STLExporter.js'));
+
   readonly #parsers = {
     OBJ: (model: Object3D) => defer(() => import('three/examples/jsm/exporters/OBJExporter.js')).pipe(
       map(({ OBJExporter }) => new OBJExporter().parse(model)),
@@ -123,11 +126,8 @@ export class ExportService {
         }
         const { blob, currentGroup } = info;
         const name = this.normalizeName(fileName, currentGroup.identifier, '.zip');
-        const size = blob.size;
 
-        return this.downloadBlob$(name, blob).pipe(
-          map(() => ({ name, size })),
-        );
+        return this.downloadBlob$(name, blob);
       }),
     )
   }
@@ -148,10 +148,7 @@ export class ExportService {
           ext = blob.type.slice(6) as typeof ext;
         }
         const name = this.normalizeName(null, baseName, `.${ext}`);
-        const size = blob.size;
-        return this.downloadBlob$(name, blob).pipe(
-          map(() => ({ name, size })),
-        );
+        return this.downloadBlob$(name, blob);
       }),
     );
   }
@@ -168,9 +165,7 @@ export class ExportService {
       const size = blob.size;
       console.info('Download SVG context:', { name, size, renderInfo });
 
-      return this.downloadBlob$(name, blob).pipe(
-        map(() => ({ name, size, renderInfo })),
-      );
+      return this.downloadBlob$(name, blob);
     });
   }
 
@@ -186,7 +181,8 @@ export class ExportService {
 
       return timer(10).pipe(
         tap(() => URL.revokeObjectURL(url)),
-      )
+        map(() => ({ name: filename, size: blob.size })),
+      );
     });
   }
 
@@ -203,7 +199,7 @@ export class ExportService {
     );
   }
 
-  downloadModel$<T extends ModelExporterNames>(baseName: string, type: T) {
+  downloadModel$<T extends ModelExporterNames>(baseName: string, type: T, gzipCompress: boolean) {
     const [ext, mime] = modelExporterExtensions[type];
 
     const name = this.normalizeName(null, baseName, `.${ext}`);
@@ -215,9 +211,14 @@ export class ExportService {
         }
         const blob = new Blob([result], { type: mime });
 
-        return this.downloadBlob$(name, blob).pipe(
-          map(() => ({ name, size: blob.size })),
-        );
+        if (gzipCompress) {
+          const compressedName = `${name}.gz`;
+          return this.#compressionService.compressOrDecompressBlob$(true, blob, 'gzip').pipe(
+            switchMap(compressedBlob => this.downloadBlob$(compressedName, compressedBlob)),
+          );
+        } else {
+          return this.downloadBlob$(name, blob);
+        }
       }),
     );
   }

--- a/src/app/shared/services/export.service.ts
+++ b/src/app/shared/services/export.service.ts
@@ -87,9 +87,9 @@ export class ExportService {
       map(({ STLExporter }) => new STLExporter().parse(model, { binary: false })),
     ),
     USDZ: (model: Object3D) => defer(() => import('three/examples/jsm/exporters/USDZExporter.js')).pipe(
-      map(({ USDZExporter }) => new USDZExporter().parse(model, { quickLookCompatible: true })),
+      switchMap(({ USDZExporter }) => new USDZExporter().parse(model, {quickLookCompatible: true})),
     ),
-  } satisfies Record<ModelExporterNames, any>;
+  } satisfies Record<ModelExporterNames, (model: Object3D) => any>;
 
   /**
    * Trigger a browser download of the currentOpenGroup.

--- a/src/app/shared/services/zip.service.ts
+++ b/src/app/shared/services/zip.service.ts
@@ -55,6 +55,7 @@ export class ZipService {
         });
       }),
       last(),
+      tap(() => console.info('zipped last entry, starting compression...')),
       switchMap(() => this.zipZipWithTransportProgress({
         zip,
         fileComment,


### PR DESCRIPTION
Version 0.3.7

Bugfix:
* USDZExporter should be `switchMap`'d not `map`'d

Core changes:
* allow user to GZip any exported model.
* Introduce CompressionService that provides cancellable compression and decompression streaming
* improve descriptions in export-model-dialog.