### PR TITLE
User defined materials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavern-seer-mapper",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "homepage": "https://github.com/skgrush/cavern-seer-mapper#readme",
   "license": "MIT",
   "author": {

--- a/src/app/dialogs/open-dialog/open-dialog.component.html
+++ b/src/app/dialogs/open-dialog/open-dialog.component.html
@@ -10,7 +10,7 @@
       </mat-list-item>
       }
     </mat-list>
-    <input *ngIf="!hasInitialFiles" #fileInput type="file" [multiple]="!!multiple" (change)="inputChanged($event)">
+    <input *ngIf="!hasInitialFiles" type="file" [multiple]="multiple" [accept]="accept" (change)="inputChanged($event)">
 
     <ng-container *ngIf="uploadProgress.progress$ | async as progress">
       <div class="loading-container" *ngIf="progress.active">

--- a/src/app/dialogs/open-dialog/open-dialog.component.ts
+++ b/src/app/dialogs/open-dialog/open-dialog.component.ts
@@ -21,6 +21,7 @@ export type IOpenDialogData = {
   readonly submitText: string;
   readonly multiple?: boolean;
   readonly initialFiles?: FileList;
+  readonly accept?: string;
 };
 
 @Component({
@@ -43,6 +44,7 @@ export class OpenDialogComponent implements OnInit {
   readonly submitText = this.#dialogData.submitText;
   readonly multiple = this.#dialogData.multiple;
   readonly hasInitialFiles = !!this.#dialogData.initialFiles?.length;
+  readonly accept = this.#dialogData.accept ?? '*/*';
 
   protected readonly uploadProgress = new TransportProgressHandler();
 

--- a/src/app/shared/components/file-icon/file-icon.component.ts
+++ b/src/app/shared/components/file-icon/file-icon.component.ts
@@ -23,6 +23,7 @@ export class FileIconComponent {
     obj: 'shape_line',
     cavernseerscan: 'svg:CavernSeer',
     walls: 'ssid_chart',
+    mtl: 'texture',
   } satisfies Record<FileModelType, string>);
 
 

--- a/src/app/shared/models/model-type.enum.ts
+++ b/src/app/shared/models/model-type.enum.ts
@@ -10,4 +10,6 @@ export enum FileModelType {
   cavernseerscan = 'cavernseerscan',
   /** Walls */
   walls = 'walls',
+  /** Material Library File */
+  mtl = 'mtl',
 }

--- a/src/app/shared/models/render/any-render-model.ts
+++ b/src/app/shared/models/render/any-render-model.ts
@@ -4,6 +4,7 @@ import type { GroupRenderModel } from './group.render-model';
 import type { ObjRenderModel } from './obj.render-model';
 import type { UnknownRenderModel } from './unknown.render-model';
 import type { WallsRenderModel } from './walls.render-model';
+import type { MtlRenderModel } from './mtl.render-model';
 
 export type AnyRenderModel =
   | GltfRenderModel
@@ -11,4 +12,5 @@ export type AnyRenderModel =
   | ObjRenderModel
   | CavernSeerScanRenderModel
   | WallsRenderModel
+  | MtlRenderModel
   | UnknownRenderModel;

--- a/src/app/shared/models/render/base.render-model.ts
+++ b/src/app/shared/models/render/base.render-model.ts
@@ -36,6 +36,7 @@ export abstract class BaseRenderModel<T extends FileModelType> {
 export abstract class BaseVisibleRenderModel<T extends FileModelType> extends BaseRenderModel<T> {
   abstract readonly visible: boolean;
   protected abstract readonly _group: Group;
+  protected abstract readonly _hasCustomTexture: boolean;
 
   abstract getAnnotations(): readonly BaseAnnotation[];
 
@@ -58,6 +59,9 @@ export abstract class BaseVisibleRenderModel<T extends FileModelType> extends Ba
    * on all meshes which are annotated with {@link IMapperUserData.fromSerializedModel}.
    */
   setMaterial(material: BaseMaterialService<any>): void {
+    if (this._hasCustomTexture) {
+      return;
+    }
     this._group.traverse(child => {
       if (child instanceof Mesh && (child.userData as IMapperUserData).fromSerializedModel) {
         material.updateMesh(child);

--- a/src/app/shared/models/render/cavern-seer-scan.render-model.ts
+++ b/src/app/shared/models/render/cavern-seer-scan.render-model.ts
@@ -55,6 +55,7 @@ export class CavernSeerScanRenderModel extends BaseVisibleRenderModel<FileModelT
   protected override get _group() {
     return this.#group;
   }
+  protected override readonly _hasCustomTexture: boolean;
 
   readonly #blob: Blob;
   readonly #parsedScanFile: IScanFileParsed;
@@ -72,6 +73,7 @@ export class CavernSeerScanRenderModel extends BaseVisibleRenderModel<FileModelT
     this.identifier = identifier;
     this.comment = comment;
     this.#blob = blob;
+    this._hasCustomTexture = false;
 
     this.#parsedScanFile = parsedScanFile;
     this.#group = parsedScanFile.group;

--- a/src/app/shared/models/render/gltf.render-model.ts
+++ b/src/app/shared/models/render/gltf.render-model.ts
@@ -28,6 +28,7 @@ export class GltfRenderModel extends BaseVisibleRenderModel<FileModelType.gLTF> 
   protected override get _group() {
     return this.#gltf.scene;
   }
+  protected override readonly _hasCustomTexture: boolean;
 
   readonly #blob: Blob;
   readonly #gltf: GLTF;
@@ -46,6 +47,7 @@ export class GltfRenderModel extends BaseVisibleRenderModel<FileModelType.gLTF> 
     this.#blob = blob;
     this.#gltf = gltf;
     this.comment = comment;
+    this._hasCustomTexture = false;
 
     const object = gltf.scene;
     this.#boxHelper = new BoxHelper(object);

--- a/src/app/shared/models/render/group.render-model.ts
+++ b/src/app/shared/models/render/group.render-model.ts
@@ -27,6 +27,7 @@ export class GroupRenderModel extends BaseVisibleRenderModel<FileModelType.group
   protected override get _group() {
     return this.#group;
   }
+  protected override readonly _hasCustomTexture = false;
 
   readonly #group = new Group();
   readonly #annotations = new Set<BaseAnnotation>();

--- a/src/app/shared/models/render/group.render-model.ts
+++ b/src/app/shared/models/render/group.render-model.ts
@@ -8,6 +8,7 @@ import { FileModelType } from '../model-type.enum';
 import { ISimpleVector3 } from '../simple-types';
 import { BaseRenderModel, BaseVisibleRenderModel } from './base.render-model';
 import { moveItemInArray } from '@angular/cdk/drag-drop';
+import { IUnzipDirEntry } from '../../services/zip.service';
 
 
 export class GroupRenderModel extends BaseVisibleRenderModel<FileModelType.group> {
@@ -15,7 +16,7 @@ export class GroupRenderModel extends BaseVisibleRenderModel<FileModelType.group
   readonly #childOrPropertyChanged = new Subject<ModelChangeType>();
   override readonly childOrPropertyChanged$ = this.#childOrPropertyChanged.asObservable();
   override identifier: string;
-  override readonly comment = null;
+  override comment: string | null;
   override readonly rendered = true;
   override get position() {
     return this.#group.position;
@@ -42,14 +43,26 @@ export class GroupRenderModel extends BaseVisibleRenderModel<FileModelType.group
 
   constructor(
     identifier: string,
+    comment: string | null,
   ) {
     super();
     this.identifier = identifier;
     this.#group.name = identifier;
+
+    this.comment = comment;
   }
 
   public static fromModels(identifier: string, models: BaseRenderModel<any>[]) {
-    const group = new GroupRenderModel(identifier);
+    const group = new GroupRenderModel(identifier, null);
+
+    for (const model of models) {
+      group.addModel(model);
+    }
+    return group;
+  }
+
+  public static fromUnzipDirEntry(entry: IUnzipDirEntry, models: BaseRenderModel<any>[]) {
+    const group = new GroupRenderModel(entry.name, entry.comment);
 
     for (const model of models) {
       group.addModel(model);
@@ -154,8 +167,9 @@ export class GroupRenderModel extends BaseVisibleRenderModel<FileModelType.group
     return true;
   }
 
-  override setComment(): boolean {
-    return false;
+  override setComment(comment:string | null): boolean {
+    this.comment = comment;
+    return true;
   }
 
   override setPosition({ x, y, z }: ISimpleVector3): boolean {

--- a/src/app/shared/models/render/mtl.render-model.ts
+++ b/src/app/shared/models/render/mtl.render-model.ts
@@ -1,0 +1,57 @@
+import { BaseRenderModel } from './base.render-model';
+import { FileModelType } from '../model-type.enum';
+import { Subject } from 'rxjs';
+import { ModelChangeType } from '../model-change-type.enum';
+import { Group, Object3DEventMap, Vector3 } from 'three';
+import { UploadFileModel } from '../upload-file-model';
+import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader';
+
+export class MtlRenderModel extends BaseRenderModel<FileModelType.mtl> {
+  override readonly type = FileModelType.mtl;
+  readonly #childOrPropertyChanged = new Subject<ModelChangeType>();
+  override readonly childOrPropertyChanged$ = this.#childOrPropertyChanged.asObservable();
+  override readonly position: Readonly<Vector3> = new Vector3();
+  override identifier: string;
+  override comment: string | null;
+  override readonly rendered = false;
+
+  readonly #blob: Blob;
+  readonly materialCreator: MTLLoader.MaterialCreator;
+
+  constructor(
+    identifier: string,
+    comment: string | null,
+    blob: Blob,
+    loader: MTLLoader.MaterialCreator,
+  ) {
+    super();
+    this.identifier = identifier;
+    this.comment = comment;
+    this.#blob = blob;
+    this.materialCreator = loader;
+  }
+
+  static fromUploadModel(uploadModel: UploadFileModel, loader: MTLLoader.MaterialCreator) {
+    const { identifier, blob, comment } = uploadModel;
+    return new MtlRenderModel(identifier, comment, blob, loader);
+  }
+
+  override serialize() {
+    return this.#blob;
+  }
+
+  override rename(name: string): boolean {
+    this.identifier = name;
+    this.#childOrPropertyChanged.next(ModelChangeType.MetadataChanged);
+    return true;
+  }
+
+  override setComment(comment: string | null): boolean {
+    this.comment = comment;
+    return true;
+  }
+
+  override addToGroup(group: Group<Object3DEventMap>): void { }
+  override removeFromGroup(group: Group<Object3DEventMap>): void { }
+  override dispose(): void { }
+}

--- a/src/app/shared/models/render/obj.render-model.ts
+++ b/src/app/shared/models/render/obj.render-model.ts
@@ -55,7 +55,7 @@ export class ObjRenderModel extends BaseVisibleRenderModel<FileModelType.obj> {
     })
   }
 
-  static fromUploadModel(uploadModel: UploadFileModel, object: Group, hasCustomTexture: boolean = false) {
+  static fromUploadModel(uploadModel: UploadFileModel, object: Group, hasCustomTexture: boolean) {
     const { identifier, blob, comment } = uploadModel;
     object.name = uploadModel.identifier;
     return new ObjRenderModel(

--- a/src/app/shared/models/render/obj.render-model.ts
+++ b/src/app/shared/models/render/obj.render-model.ts
@@ -26,6 +26,7 @@ export class ObjRenderModel extends BaseVisibleRenderModel<FileModelType.obj> {
   protected override get _group() {
     return this.#object;
   }
+  protected override readonly _hasCustomTexture: boolean;
 
   readonly #object: Group;
   readonly #boxHelper: BoxHelper;
@@ -37,11 +38,13 @@ export class ObjRenderModel extends BaseVisibleRenderModel<FileModelType.obj> {
     object: Group,
     blob: Blob,
     comment: string | null,
+    hasCustomTexture: boolean,
   ) {
     super();
     this.#object = object;
     this.#blob = blob;
     this.#boxHelper = new BoxHelper(object);
+    this._hasCustomTexture = hasCustomTexture;
 
     this.identifier = identifier;
     this.comment = comment;
@@ -52,7 +55,7 @@ export class ObjRenderModel extends BaseVisibleRenderModel<FileModelType.obj> {
     })
   }
 
-  static fromUploadModel(uploadModel: UploadFileModel, object: Group) {
+  static fromUploadModel(uploadModel: UploadFileModel, object: Group, hasCustomTexture: boolean = false) {
     const { identifier, blob, comment } = uploadModel;
     object.name = uploadModel.identifier;
     return new ObjRenderModel(
@@ -60,6 +63,7 @@ export class ObjRenderModel extends BaseVisibleRenderModel<FileModelType.obj> {
       object,
       blob,
       comment,
+      hasCustomTexture,
     );
   }
 

--- a/src/app/shared/models/render/walls.render-model.ts
+++ b/src/app/shared/models/render/walls.render-model.ts
@@ -28,6 +28,7 @@ export class WallsRenderModel extends BaseVisibleRenderModel<FileModelType.walls
   protected override get _group() {
     return this.#group;
   }
+  protected override readonly _hasCustomTexture = true;
 
   readonly #blob: Blob;
   readonly #walls: PrimitiveWallsFile;

--- a/src/app/shared/models/upload-file-model.ts
+++ b/src/app/shared/models/upload-file-model.ts
@@ -25,11 +25,11 @@ export class UploadFileModel {
     );
   }
 
-  static fromUnzip(unzipEntry: IUnzipFileEntry, blob: Blob, type: FileModelType) {
+  static fromUnzip(unzipEntry: IUnzipFileEntry, type: FileModelType) {
     return new UploadFileModel(
       unzipEntry.name,
-      blob,
-      blob.type,
+      unzipEntry.blob,
+      unzipEntry.blob.type,
       type,
       unzipEntry.comment,
     );

--- a/src/app/shared/services/dialog-opener.service.ts
+++ b/src/app/shared/services/dialog-opener.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, Injector, inject } from '@angular/core';
+import { inject, Injectable, Injector } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ModelManagerService } from './model-manager.service';
 import { ICrossSectionRenderDialogData } from '../../dialogs/cross-section-render-dialog/cross-section-render-dialog.component';
 import { defer, switchMap } from 'rxjs';
+import { FileTypeService } from './file-type.service';
 
 /**
  * Service solely responsible for opening dialogs
@@ -13,6 +14,7 @@ export class DialogOpenerService {
   readonly #modelManager = inject(ModelManagerService);
   readonly #dialog = inject(MatDialog);
   readonly #injector = inject(Injector);
+  readonly #fileTypeService = inject(FileTypeService);
 
   open() {
     import('../../dialogs/open-dialog/open-dialog.component')
@@ -21,6 +23,7 @@ export class DialogOpenerService {
           submitText: 'Open',
           titleText: 'Open a file',
           multiple: false,
+          accept: this.#fileTypeService.getAllExtensionsAndMimes().join(','),
         }).afterClosed().subscribe(result => {
           if (result) {
             this.#modelManager.resetToNonGroupModel(result[0]);
@@ -44,6 +47,7 @@ export class DialogOpenerService {
           submitText: 'Import',
           titleText: 'Import one or more files',
           multiple: true,
+          accept: this.#fileTypeService.getAllExtensionsAndMimes().join(','),
           initialFiles,
         }).afterClosed().subscribe(result => {
           if (result) {

--- a/src/app/shared/services/file-type.service.ts
+++ b/src/app/shared/services/file-type.service.ts
@@ -16,6 +16,22 @@ export class FileTypeService {
     [FileModelType.mtl]: '.mtl',
   } as const;
 
+  readonly mimes = {
+    [FileModelType.obj]: 'model/obj',
+    [FileModelType.gLTF]: ['model/gltf+json', 'model/gltf-binary'],
+    [FileModelType.group]: 'application/zip',
+    [FileModelType.walls]: 'model/vrml',
+    [FileModelType.cavernseerscan]: 'application/vnd.org.grush.cavernseer.scan',
+    [FileModelType.mtl]: 'model/mtl',
+  } as const;
+
+  getAllExtensionsAndMimes() {
+    return [
+      ...Object.values(this.extensions),
+      ...Object.values(this.mimes),
+    ].flat();
+  }
+
   *mapFileList(files: FileList) {
     for (let i = 0; i < files.length; ++i) {
       yield this.mapFileModel(files[i]);
@@ -80,20 +96,19 @@ export class FileTypeService {
   }
 
   isObj(mime: string, name: string) {
-    return mime === 'model/obj' || this.getFileExtension(name) === this.extensions.obj;
+    return mime === this.mimes.obj || this.getFileExtension(name) === this.extensions.obj;
   }
 
   isGltf(mime: string, name: string) {
     const ext = this.getFileExtension(name);
     return (
-      mime === 'model/gltf+json' ||
-      mime === 'model/gltf-binary' ||
-      this.extensions.gltf.includes(ext as '.gltf' | '.glb')
+      this.mimes.gltf.includes(mime as any) ||
+      this.extensions.gltf.includes(ext as any)
     );
   }
 
   isZip(mime: string, name: string) {
-    return mime === 'application/zip' || this.getFileExtension(name) === this.extensions.group;
+    return mime === this.mimes.group || this.getFileExtension(name) === this.extensions.group;
   }
 
   isSupportedGroupArchive(mime: string, name: string) {
@@ -101,14 +116,14 @@ export class FileTypeService {
   }
 
   isCavernSeerScan(mime: string, name: string) {
-    return mime === 'application/vnd.org.grush.cavernseer.scan' || this.getFileExtension(name) === this.extensions.cavernseerscan;
+    return mime === this.mimes.cavernseerscan || this.getFileExtension(name) === this.extensions.cavernseerscan;
   }
 
   isVrmlFile(mime: string, name: string) {
-    return mime === 'model/vrml' || this.getFileExtension(name) === this.extensions.walls;
+    return mime === this.mimes.walls || this.getFileExtension(name) === this.extensions.walls;
   }
 
   isMtlFile(mime: string, name: string) {
-    return mime === 'model/mtl' || this.getFileExtension(name) === this.extensions.mtl;
+    return mime === this.mimes.mtl || this.getFileExtension(name) === this.extensions.mtl;
   }
 }

--- a/src/app/shared/services/file-type.service.ts
+++ b/src/app/shared/services/file-type.service.ts
@@ -13,6 +13,7 @@ export class FileTypeService {
     [FileModelType.group]: '.zip',
     [FileModelType.walls]: '.wrl',
     [FileModelType.cavernseerscan]: '.cavernseerscan',
+    [FileModelType.mtl]: '.mtl',
   } as const;
 
   *mapFileList(files: FileList) {
@@ -44,7 +45,27 @@ export class FileTypeService {
     if (this.isVrmlFile(mime, name)) {
       return FileModelType.walls;
     }
+    if (this.isMtlFile(mime, name)) {
+      return FileModelType.mtl;
+    }
+
     return FileModelType.unknown;
+  }
+
+  isVisibleRenderModelType(type: FileModelType) {
+    switch (type) {
+      case FileModelType.obj:
+      case FileModelType.gLTF:
+      case FileModelType.walls:
+      case FileModelType.group:
+      case FileModelType.cavernseerscan:
+        return true;
+      case FileModelType.unknown:
+      case FileModelType.mtl:
+        return false;
+      default:
+        throw new Error(`Unknown FileModelType: ${type satisfies never}`);
+    }
   }
 
   /**
@@ -85,5 +106,9 @@ export class FileTypeService {
 
   isVrmlFile(mime: string, name: string) {
     return mime === 'model/vrml' || this.getFileExtension(name) === this.extensions.walls;
+  }
+
+  isMtlFile(mime: string, name: string) {
+    return mime === 'model/mtl' || this.getFileExtension(name) === this.extensions.mtl;
   }
 }

--- a/src/app/shared/services/model-load.service.ts
+++ b/src/app/shared/services/model-load.service.ts
@@ -578,6 +578,10 @@ class UnzippedDirectoryOpener {
   }
 }
 
+/**
+ * LoadingManager for using ThreeJS loaders inside of zip contexts
+ * (converts "URL" loading to relative blob loading).
+ */
 class ZipRelativeLoadingManager extends LoadingManager {
 
   #objectURLRegistry = new Set<string>();

--- a/src/app/shared/services/model-load.service.ts
+++ b/src/app/shared/services/model-load.service.ts
@@ -28,9 +28,9 @@ import { UploadFileModel } from '../models/upload-file-model';
 import { ignoreNullishArray } from '../operators/ignore-nullish';
 import { AnnotationBuilderService } from './annotation-builder.service';
 import { FileTypeService } from './file-type.service';
-import type { IUnzipDirEntry, IUnzipEntry, IUnzipFileEntry, IZipEntry } from './zip.service';
+import type { IUnzipDirEntry, IUnzipFileEntry, IZipEntry } from './zip.service';
 import { WallsRenderModel } from '../models/render/walls.render-model';
-import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader';
+import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader.js';
 import { MtlRenderModel } from '../models/render/mtl.render-model';
 
 type IModelLoadResult<T extends BaseRenderModel<any>> = {

--- a/src/app/shared/services/model-load.service.ts
+++ b/src/app/shared/services/model-load.service.ts
@@ -489,7 +489,7 @@ export class ModelLoadService {
     }
     return mtlModel.loadRenderModel$().pipe(
       map(renderModel => {
-        if (!renderModel || renderModel instanceof MtlRenderModel) {
+        if (renderModel instanceof MtlRenderModel) {
           return renderModel;
         }
         throw new Error(`Weird case where #findMtlLibInObj() tried to load a non MTL render model?`);


### PR DESCRIPTION
Version 0.3.10.

Core changes:
* Add support for loading MTL files
* Visible render models support `_hasCustomTexture` flag which prevents overriding with our material switcher
* total overhaul of zip loading
   - `UnzippedDirectoryOpener`/`UnzippedFileOpener` eagerly construct a file tree, allowing relative referencing of files during loading, but lazily generate models when requested
   - `ZipRelativeLoadingManager` used internally for using ThreeJS loaders inside of zip contexts (converts "path" loading to relative blob loading)
   - load-OBJ logic supports using loaded MTL files

Additional changes:
* open and import dialogs set "accept" filter based on file extensions and mime types that are supported
* `IUnzipFileEntry`s eagerly load their blobs instead of deferring it; there was really no benefit there.