### PR TITLE
Keybindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ npm-debug.log
 yarn-error.log
 
 # IDEs and editors
-.idea/
 .project
 .classpath
 .c9/

--- a/.idea/.idea.cavern-seer-mapper.dir/.idea/.gitignore
+++ b/.idea/.idea.cavern-seer-mapper.dir/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/contentModel.xml
+/.idea.cavern-seer-mapper.iml
+/projectSettingsUpdater.xml
+/modules.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.cavern-seer-mapper.dir/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/.idea.cavern-seer-mapper.dir/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/.idea.cavern-seer-mapper.dir/.idea/indexLayout.xml
+++ b/.idea/.idea.cavern-seer-mapper.dir/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.cavern-seer-mapper.dir/.idea/vcs.xml
+++ b/.idea/.idea.cavern-seer-mapper.dir/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/.idea.cavern-seer-mapper.dir/.idea/watcherTasks.xml
+++ b/.idea/.idea.cavern-seer-mapper.dir/.idea/watcherTasks.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectTasksOptions" suppressed-tasks="SCSS" />
+</project>

--- a/angular.json
+++ b/angular.json
@@ -34,6 +34,9 @@
               "src/assets",
               "src/manifest.webmanifest"
             ],
+            "loader": {
+              ".glsl": "text"
+            },
             "styles": [
               "@angular/material/prebuilt-themes/purple-green.css",
               "src/styles.scss"
@@ -43,6 +46,7 @@
             ],
             "scripts": [],
             "prerender": false,
+
             "namedChunks": true
           },
           "configurations": {

--- a/angular.json
+++ b/angular.json
@@ -46,7 +46,6 @@
             ],
             "scripts": [],
             "prerender": false,
-
             "namedChunks": true
           },
           "configurations": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavern-seer-mapper",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "homepage": "https://github.com/skgrush/cavern-seer-mapper#readme",
   "license": "MIT",
   "author": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,6 +32,7 @@ export class AppComponent {
 
   @HostListener('keybdown', ['$event'])
   keydown(e: KeyboardEvent) {
+    console.debug('keydown', e.key, e);
     const called = this.#keybind.keyEventCalled(e);
     if (called) {
       e.preventDefault();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -33,8 +33,8 @@ export class AppComponent {
   @HostListener('keydown', ['$event'])
   keydown(e: KeyboardEvent) {
     console.debug('keydown', e.key, e);
-    const called = this.#keybind.keyEventCalled(e);
-    if (called) {
+    const handled = this.#keybind.keyEventCalled(e);
+    if (handled) {
       e.preventDefault();
     }
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,7 +30,7 @@ export class AppComponent {
     e.preventDefault();
   }
 
-  @HostListener('keybdown', ['$event'])
+  @HostListener('keydown', ['$event'])
   keydown(e: KeyboardEvent) {
     console.debug('keydown', e.key, e);
     const called = this.#keybind.keyEventCalled(e);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, HostListener } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterOutlet } from '@angular/router';
+import { KeyBindService } from './shared/services/key-bind.service';
 
 @Component({
   selector: 'mapper-root',
@@ -15,6 +16,7 @@ import { RouterOutlet } from '@angular/router';
   imports: [CommonModule, RouterOutlet, MatSidenavModule, MatButtonModule, MatIconModule, MatTooltipModule]
 })
 export class AppComponent {
+  readonly #keybind = inject(KeyBindService);
 
   @HostListener('dragover', ['$event'])
   dragOver(e: DragEvent) {
@@ -26,5 +28,13 @@ export class AppComponent {
   drop(e: DragEvent) {
     console.info('drop on app', e);
     e.preventDefault();
+  }
+
+  @HostListener('keybdown', ['$event'])
+  keydown(e: KeyboardEvent) {
+    const called = this.#keybind.keyEventCalled(e);
+    if (called) {
+      e.preventDefault();
+    }
   }
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -15,6 +15,7 @@ import { LOCAL_STORAGE } from './shared/tokens/local-storage.token';
 import { MAPPER_VERSION, VersionObject } from './shared/tokens/version.token';
 import { provideHttpClient } from '@angular/common/http';
 import { KeyBindService } from './shared/services/key-bind.service';
+import { PlatformService } from './shared/services/platform.service';
 
 
 export const appConfig: ApplicationConfig = {
@@ -25,6 +26,7 @@ export const appConfig: ApplicationConfig = {
     ErrorService,
     AlertService,
     KeyBindService,
+    PlatformService,
     importProvidersFrom(MatSnackBarModule),
     {
       provide: MAT_SNACK_BAR_DEFAULT_OPTIONS,

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -14,6 +14,7 @@ import { INTL_UNIT_LIST_FORMAT } from './shared/tokens/intl-unit-list-format.tok
 import { LOCAL_STORAGE } from './shared/tokens/local-storage.token';
 import { MAPPER_VERSION, VersionObject } from './shared/tokens/version.token';
 import { provideHttpClient } from '@angular/common/http';
+import { KeyBindService } from './shared/services/key-bind.service';
 
 
 export const appConfig: ApplicationConfig = {
@@ -23,6 +24,7 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(),
     ErrorService,
     AlertService,
+    KeyBindService,
     importProvidersFrom(MatSnackBarModule),
     {
       provide: MAT_SNACK_BAR_DEFAULT_OPTIONS,

--- a/src/app/pages/sidenav/sidenav.component.html
+++ b/src/app/pages/sidenav/sidenav.component.html
@@ -1,11 +1,11 @@
 <mat-list>
-  <button mat-list-item [mapperKeyBind]="'ctrl+o'" matTooltip="ctrl+o" (click)="openDialog.openAFile$().subscribe()">Open...</button>
-  <button mat-list-item [mapperKeyBind]="'ctrl+i'" matTooltip="ctrl+i" (click)="openDialog.importFiles$().subscribe()">Import...</button>
-  <button mat-list-item [mapperKeyBind]="'ctrl+s'" matTooltip="ctrl+s" (click)="saveDialog.saveOpenFile$().subscribe()">Save zip...</button>
-  <button mat-list-item [mapperKeyBind]="'ctrl+e'" matTooltip="ctrl+e" (click)="exportImageDialog.exportImage$().subscribe()">Export image...</button>
-  <button mat-list-item [mapperKeyBind]="'ctrl+shift+e'" matTooltip="ctrl+shift+e" (click)="exportModelDialog.exportModel$().subscribe()">Export model...</button>
-  <button mat-list-item (click)="settingsDialog.openSettings$().subscribe()">Settings</button>
-  <button mat-list-item (click)="serviceWorker.checkForUpdate().subscribe()">Check for update</button>
+  <button mat-list-item [mapperKeyBind]="'ctrl+o'" (click)="openDialog.openAFile$().subscribe()"><span>Open... <mapper-key-bind-icon /></span></button>
+  <button mat-list-item [mapperKeyBind]="'ctrl+i'" (click)="openDialog.importFiles$().subscribe()"><span>Import... <mapper-key-bind-icon /></span></button>
+  <button mat-list-item [mapperKeyBind]="'ctrl+s'" (click)="saveDialog.saveOpenFile$().subscribe()"><span>Save zip... <mapper-key-bind-icon /></span></button>
+  <button mat-list-item [mapperKeyBind]="'ctrl+e'" (click)="exportImageDialog.exportImage$().subscribe()"><span>Export image... <mapper-key-bind-icon /></span></button>
+  <button mat-list-item [mapperKeyBind]="'ctrl+shift+e'" (click)="exportModelDialog.exportModel$().subscribe()"><span>Export model... <mapper-key-bind-icon /></span></button>
+  <button mat-list-item (click)="settingsDialog.openSettings$().subscribe()"><span>Settings</span></button>
+  <button mat-list-item (click)="serviceWorker.checkForUpdate().subscribe()"><span>Check for update</span></button>
 </mat-list>
 <div class="footer">
   <p>{{ mapperVersion.version }}</p>

--- a/src/app/pages/sidenav/sidenav.component.html
+++ b/src/app/pages/sidenav/sidenav.component.html
@@ -1,9 +1,9 @@
 <mat-list>
-  <button mat-list-item (click)="openDialog.openAFile$().subscribe()">Open...</button>
-  <button mat-list-item (click)="openDialog.importFiles$().subscribe()">Import...</button>
-  <button mat-list-item (click)="saveDialog.saveOpenFile$().subscribe()">Save zip...</button>
-  <button mat-list-item (click)="exportImageDialog.exportImage$().subscribe()">Export image...</button>
-  <button mat-list-item (click)="exportModelDialog.exportModel$().subscribe()">Export model...</button>
+  <button mat-list-item [mapperKeyBind]="'ctrl+o'" matTooltip="ctrl+o" (click)="openDialog.openAFile$().subscribe()">Open...</button>
+  <button mat-list-item [mapperKeyBind]="'ctrl+i'" matTooltip="ctrl+i" (click)="openDialog.importFiles$().subscribe()">Import...</button>
+  <button mat-list-item [mapperKeyBind]="'ctrl+s'" matTooltip="ctrl+s" (click)="saveDialog.saveOpenFile$().subscribe()">Save zip...</button>
+  <button mat-list-item [mapperKeyBind]="'ctrl+e'" matTooltip="ctrl+e" (click)="exportImageDialog.exportImage$().subscribe()">Export image...</button>
+  <button mat-list-item [mapperKeyBind]="'ctrl+shift+e'" matTooltip="ctrl+shift+e" (click)="exportModelDialog.exportModel$().subscribe()">Export model...</button>
   <button mat-list-item (click)="settingsDialog.openSettings$().subscribe()">Settings</button>
   <button mat-list-item (click)="serviceWorker.checkForUpdate().subscribe()">Check for update</button>
 </mat-list>

--- a/src/app/pages/sidenav/sidenav.component.scss
+++ b/src/app/pages/sidenav/sidenav.component.scss
@@ -5,5 +5,11 @@
 
   mat-list {
     overflow-y: auto;
+
+    button[mat-list-item] span:not(span[class]) {
+      display: flex;
+      justify-content: space-between;
+      width: 100%;
+    }
   }
 }

--- a/src/app/pages/sidenav/sidenav.component.scss
+++ b/src/app/pages/sidenav/sidenav.component.scss
@@ -6,10 +6,12 @@
   mat-list {
     overflow-y: auto;
 
-    button[mat-list-item] span:not(span[class]) {
-      display: flex;
-      justify-content: space-between;
-      width: 100%;
+    button[mat-list-item] {
+      span:not(span[class]) {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+      }
     }
   }
 }

--- a/src/app/pages/sidenav/sidenav.component.ts
+++ b/src/app/pages/sidenav/sidenav.component.ts
@@ -10,11 +10,13 @@ import {
   SaveDialogOpener,
   SettingsDialogOpener,
 } from '../../dialogs';
+import { KeyBindDirective } from '../../shared/directives/key-bind.directive';
+import { MatTooltip } from '@angular/material/tooltip';
 
 @Component({
   selector: 'mapper-sidenav',
   standalone: true,
-  imports: [MatListModule, AsyncPipe, NgIf],
+  imports: [MatListModule, AsyncPipe, NgIf, KeyBindDirective, MatTooltip],
   templateUrl: './sidenav.component.html',
   styleUrl: './sidenav.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/pages/sidenav/sidenav.component.ts
+++ b/src/app/pages/sidenav/sidenav.component.ts
@@ -12,11 +12,12 @@ import {
 } from '../../dialogs';
 import { KeyBindDirective } from '../../shared/directives/key-bind.directive';
 import { MatTooltip } from '@angular/material/tooltip';
+import { KeyBindIconComponent } from '../../shared/components/key-bind-icon/key-bind-icon.component';
 
 @Component({
   selector: 'mapper-sidenav',
   standalone: true,
-  imports: [MatListModule, AsyncPipe, NgIf, KeyBindDirective, MatTooltip],
+  imports: [MatListModule, AsyncPipe, NgIf, KeyBindDirective, MatTooltip, KeyBindIconComponent],
   templateUrl: './sidenav.component.html',
   styleUrl: './sidenav.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/pages/sidenav/sidenav.component.ts
+++ b/src/app/pages/sidenav/sidenav.component.ts
@@ -11,13 +11,12 @@ import {
   SettingsDialogOpener,
 } from '../../dialogs';
 import { KeyBindDirective } from '../../shared/directives/key-bind.directive';
-import { MatTooltip } from '@angular/material/tooltip';
 import { KeyBindIconComponent } from '../../shared/components/key-bind-icon/key-bind-icon.component';
 
 @Component({
   selector: 'mapper-sidenav',
   standalone: true,
-  imports: [MatListModule, AsyncPipe, NgIf, KeyBindDirective, MatTooltip, KeyBindIconComponent],
+  imports: [MatListModule, AsyncPipe, NgIf, KeyBindDirective, KeyBindIconComponent],
   templateUrl: './sidenav.component.html',
   styleUrl: './sidenav.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/shared/components/key-bind-icon/key-bind-icon.component.html
+++ b/src/app/shared/components/key-bind-icon/key-bind-icon.component.html
@@ -1,7 +1,1 @@
-<ng-container *ngIf="obj$ | async as obj">
-  <span *ngIf="obj.ctrlKey">{{ icons.ctrlKey }}</span>
-  <span *ngIf="obj.altKey">{{ icons.altKey }}</span>
-  <span *ngIf="obj.shiftKey">{{ icons.shiftKey }}</span>
-  <span *ngIf="obj.metaKey">{{ icons.metaKey }}</span>
-  <span>{{ obj.key }}</span>
-</ng-container>
+{{ localizedStr$ | async }}

--- a/src/app/shared/components/key-bind-icon/key-bind-icon.component.html
+++ b/src/app/shared/components/key-bind-icon/key-bind-icon.component.html
@@ -1,0 +1,7 @@
+<ng-container *ngIf="obj$ | async as obj">
+  <span *ngIf="obj.ctrlKey">{{ icons.ctrlKey }}</span>
+  <span *ngIf="obj.altKey">{{ icons.altKey }}</span>
+  <span *ngIf="obj.shiftKey">{{ icons.shiftKey }}</span>
+  <span *ngIf="obj.metaKey">{{ icons.metaKey }}</span>
+  <span>{{ obj.key }}</span>
+</ng-container>

--- a/src/app/shared/components/key-bind-icon/key-bind-icon.component.scss
+++ b/src/app/shared/components/key-bind-icon/key-bind-icon.component.scss
@@ -1,10 +1,4 @@
 :host {
   display: inline-flex;
   color: gray;
-
-  &:not(.icons-symbolic) span {
-    &:not(:last-child):after {
-      content: '+';
-    }
-  }
 }

--- a/src/app/shared/components/key-bind-icon/key-bind-icon.component.scss
+++ b/src/app/shared/components/key-bind-icon/key-bind-icon.component.scss
@@ -1,0 +1,8 @@
+:host {
+  display: inline-flex;
+  color: gray;
+
+  &.icons-symbolic span {
+    gap: 2px;
+  }
+}

--- a/src/app/shared/components/key-bind-icon/key-bind-icon.component.scss
+++ b/src/app/shared/components/key-bind-icon/key-bind-icon.component.scss
@@ -2,7 +2,9 @@
   display: inline-flex;
   color: gray;
 
-  &.icons-symbolic span {
-    gap: 2px;
+  &:not(.icons-symbolic) span {
+    &:not(:last-child):after {
+      content: '+';
+    }
   }
 }

--- a/src/app/shared/components/key-bind-icon/key-bind-icon.component.ts
+++ b/src/app/shared/components/key-bind-icon/key-bind-icon.component.ts
@@ -1,15 +1,14 @@
-import { ChangeDetectionStrategy, Component, HostBinding, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { KeyBindContext } from '../../directives/key-bind.directive';
-import { map, shareReplay } from 'rxjs';
+import { map } from 'rxjs';
 import { KeyBindService } from '../../services/key-bind.service';
-import { AsyncPipe, NgIf } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 
 @Component({
   selector: 'mapper-key-bind-icon',
   standalone: true,
   imports: [
     AsyncPipe,
-    NgIf,
   ],
   templateUrl: './key-bind-icon.component.html',
   styleUrl: './key-bind-icon.component.scss',
@@ -18,13 +17,8 @@ import { AsyncPipe, NgIf } from '@angular/common';
 export class KeyBindIconComponent {
   readonly #keyBindContext = inject(KeyBindContext);
   readonly #keyBindService = inject(KeyBindService);
-  readonly icons = this.#keyBindService.icons;
 
-  @HostBinding('class.icons-symbolic')
-  readonly iconsSymbolic = this.icons.symbolic;
-
-  readonly obj$ = this.#keyBindContext.keyBindString$.pipe(
-    map(str => this.#keyBindService.bindStringToObject(str)),
-    shareReplay(1),
+  readonly localizedStr$ = this.#keyBindContext.keyBindString$.pipe(
+    map(str => this.#keyBindService.localizeKeyBindString(str)),
   )
 }

--- a/src/app/shared/components/key-bind-icon/key-bind-icon.component.ts
+++ b/src/app/shared/components/key-bind-icon/key-bind-icon.component.ts
@@ -4,6 +4,10 @@ import { map } from 'rxjs';
 import { KeyBindService } from '../../services/key-bind.service';
 import { AsyncPipe } from '@angular/common';
 
+/**
+ * Should be used inside an element with the {@link mapperKeyBind} directive.
+ * A platform-localized version of the keybind icons/text are rendered.
+ */
 @Component({
   selector: 'mapper-key-bind-icon',
   standalone: true,

--- a/src/app/shared/components/key-bind-icon/key-bind-icon.component.ts
+++ b/src/app/shared/components/key-bind-icon/key-bind-icon.component.ts
@@ -1,0 +1,30 @@
+import { ChangeDetectionStrategy, Component, HostBinding, inject } from '@angular/core';
+import { KeyBindContext } from '../../directives/key-bind.directive';
+import { map, shareReplay } from 'rxjs';
+import { KeyBindService } from '../../services/key-bind.service';
+import { AsyncPipe, NgIf } from '@angular/common';
+
+@Component({
+  selector: 'mapper-key-bind-icon',
+  standalone: true,
+  imports: [
+    AsyncPipe,
+    NgIf,
+  ],
+  templateUrl: './key-bind-icon.component.html',
+  styleUrl: './key-bind-icon.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KeyBindIconComponent {
+  readonly #keyBindContext = inject(KeyBindContext);
+  readonly #keyBindService = inject(KeyBindService);
+  readonly icons = this.#keyBindService.icons;
+
+  @HostBinding('class.icons-symbolic')
+  readonly iconsSymbolic = this.icons.symbolic;
+
+  readonly obj$ = this.#keyBindContext.keyBindString$.pipe(
+    map(str => this.#keyBindService.bindStringToObject(str)),
+    shareReplay(1),
+  )
+}

--- a/src/app/shared/directives/key-bind.directive.ts
+++ b/src/app/shared/directives/key-bind.directive.ts
@@ -1,0 +1,31 @@
+import { Directive, inject, Input, Output } from '@angular/core';
+import { KeyBindService, KeyBindString } from '../services/key-bind.service';
+import { map, Subject, switchMap } from 'rxjs';
+
+@Directive({
+  selector: '[mapperKeyBind]',
+  standalone: true,
+})
+export class KeyBindDirective {
+  readonly #keyBindService = inject(KeyBindService);
+
+  readonly #keyBindString$ = new Subject<KeyBindString>();
+
+  /**
+   * The keybinding that should trigger a click.
+   */
+  @Input({ required: true })
+  set mapperKeyBind(v: KeyBindString) {
+    this.#keyBindString$.next(v);
+  }
+
+  /**
+   * Duplicate the builtin click handler so we can emulate a click
+   * if the mapped keybinding is clicked.
+   */
+  @Output('click')
+  readonly clickCallback = this.#keyBindString$.pipe(
+    switchMap(kb => this.#keyBindService.registerStr$(kb)),
+    map(() => undefined),
+  );
+}

--- a/src/app/shared/services/key-bind.service.ts
+++ b/src/app/shared/services/key-bind.service.ts
@@ -111,18 +111,25 @@ export class KeyBindService {
     return (mods.join('') + e.key.toLowerCase()) as KeyBindString;
   }
 
-  bindStringToObject(str: KeyBindString): IKeyBind {
-    let char: KeyCharacter;
+  localizeKeyBindString(str: KeyBindString) {
+    const obj = this.bindStringToObject(str);
+    const icons = this.icons;
 
-    const parts = str.split('+').filter(i => i);
-    if (str.endsWith('++')) {
-      char = '+';
-    } else {
-      char = parts[parts.length - 1] as KeyCharacter;
-    }
+    const parts = modifiers
+      .filter(mod => obj[mod])
+      .map(mod => icons[mod])
+      .concat(obj.key);
+
+    return parts.join(icons.symbolic ? '' : '+');
+  }
+
+  #plusSplitter = /(?<!\+)\+/;
+  bindStringToObject(str: KeyBindString): IKeyBind {
+    const parts = str.split(this.#plusSplitter).filter(i => i);
+    const key = parts[parts.length - 1] as KeyCharacter;
 
     return {
-      key: char,
+      key,
       altKey: parts.includes('alt'),
       metaKey: parts.includes('meta'),
       ctrlKey: parts.includes('ctrl'),

--- a/src/app/shared/services/key-bind.service.ts
+++ b/src/app/shared/services/key-bind.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { filter, fromEvent, map, Observable } from 'rxjs';
 import { ErrorService } from './error.service';
+import { Platform, PlatformService } from './platform.service';
 
 type LowerCaseCharacter = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z';
 type NumericCharacter = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
@@ -25,8 +26,28 @@ type UnSuffixKey<T extends `${string}Key`> = T extends `${infer K}Key` ? K : nev
 @Injectable()
 export class KeyBindService {
   readonly #errorService = inject(ErrorService);
+  readonly #platform = inject(PlatformService);
 
   readonly #registry = new Map<KeyBindString, (e: KeyboardEvent) => void>();
+
+  readonly icons: Record<typeof modifiers[number], string> & { symbolic: boolean };
+
+  constructor() {
+    switch (this.#platform.platform) {
+      case Platform.MacOS:
+      case Platform.iDevice:
+        this.icons = { symbolic: true, ctrlKey: '⌃', altKey: '⌥', shiftKey: '⇧', metaKey: '⌘' };
+        break;
+      case Platform.Android:
+      case Platform.Linux:
+      case Platform.Windows:
+      default:
+        this.icons = { symbolic: true, ctrlKey: '⌃', altKey: '⌥', shiftKey: '⇧', metaKey: '⊞' };
+        // this.icons = { symbolic: false, ctrlKey: 'Ctrl', altKey: 'Alt', shiftKey: 'Shift', metaKey: '⊞' };
+        break;
+    }
+  }
+
 
   /**
    * Bind the element for universal keybindings.

--- a/src/app/shared/services/key-bind.service.ts
+++ b/src/app/shared/services/key-bind.service.ts
@@ -1,0 +1,83 @@
+import { inject, Injectable } from '@angular/core';
+import { filter, fromEvent, map, Observable } from 'rxjs';
+import { ErrorService } from './error.service';
+
+type IKeyBind = {
+  readonly altKey?: boolean;
+  readonly ctrlKey?: boolean;
+  readonly shiftKey?: boolean;
+  readonly metaKey?: boolean;
+  readonly key: string;
+}
+
+const modifiers = ['ctrlKey', 'altKey', 'shiftKey', 'metaKey'] as const satisfies readonly (keyof IKeyBind)[];
+
+type KeyStr = '';
+type KeyBindString = `${'ctrl+'|''}${'alt+'|''}${'shift+'|''}${'meta+'|''}${KeyStr}`;
+
+type UnSuffixKey<T extends `${string}Key`> = T extends `${infer K}Key` ? K : never;
+
+@Injectable()
+export class KeyBindService {
+  readonly #errorService = inject(ErrorService);
+
+  readonly #registry = new Map<KeyBindString, (e: KeyboardEvent) => void>();
+
+  /**
+   * Bind the element for universal keybindings.
+   *
+   * While subscribed, registered keybindings against this element call their registered callbacks,
+   * **and `preventDefault()` on it**.
+   */
+  bindToKeyDownEvents$(ele: HTMLElement) {
+    return fromEvent<KeyboardEvent>(ele, 'keydown').pipe(
+      filter(e => this.keyEventCalled(e)),
+      map(e => e.preventDefault()),
+    );
+  }
+
+  /**
+   * Pass in a keyboard event.
+   *
+   * @returns true if-and-only-if the event matched a registered event and called the callback.
+   */
+  keyEventCalled(e: KeyboardEvent) {
+    const bindStr = this.makeBindStr(e);
+
+    const callback = this.#registry.get(bindStr);
+    try {
+      callback?.(e);
+    } catch (e) {
+      this.#errorService.handleError(e);
+    }
+
+    return !!callback;
+  }
+
+  register$(key: IKeyBind) {
+    const keyStr = this.makeBindStr(key);
+    return this.registerStr$(keyStr);
+  }
+
+  registerStr$(keyStr: KeyBindString) {
+    return new Observable<KeyboardEvent>(subscriber => {
+      if (this.#registry.has(keyStr)) {
+        subscriber.error(`Key ${keyStr} is already registered`);
+        return;
+      }
+
+      this.#registry.set(keyStr, e => subscriber.next(e));
+
+      return () => this.#registry.delete(keyStr);
+    });
+  }
+
+  makeBindStr(e: IKeyBind): KeyBindString {
+    const mods = modifiers
+      .filter(mod => e[mod])
+      .map(mod => mod.slice(0, -3) as UnSuffixKey<typeof mod>)
+      .map(modPrefix => `${modPrefix}+` as const);
+
+    return mods.join('') + e.key as '';
+  }
+}

--- a/src/app/shared/services/key-bind.service.ts
+++ b/src/app/shared/services/key-bind.service.ts
@@ -111,4 +111,23 @@ export class KeyBindService {
 
     return (mods.join('') + e.key.toLowerCase()) as KeyBindString;
   }
+
+  bindStringToObject(str: KeyBindString): IKeyBind {
+    let char: KeyCharacter;
+
+    const parts = str.split('+').filter(i => i);
+    if (str.endsWith('++')) {
+      char = '+';
+    } else {
+      char = parts[parts.length - 1] as KeyCharacter;
+    }
+
+    return {
+      key: char,
+      altKey: parts.includes('alt'),
+      metaKey: parts.includes('meta'),
+      ctrlKey: parts.includes('ctrl'),
+      shiftKey: parts.includes('shift'),
+    };
+  }
 }

--- a/src/app/shared/services/key-bind.service.ts
+++ b/src/app/shared/services/key-bind.service.ts
@@ -2,12 +2,11 @@ import { inject, Injectable } from '@angular/core';
 import { filter, fromEvent, map, Observable } from 'rxjs';
 import { ErrorService } from './error.service';
 
-type UpperCaseCharacter = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z';
-type AlphaCharacter = UpperCaseCharacter | Lowercase<UpperCaseCharacter>;
+type LowerCaseCharacter = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z';
 type NumericCharacter = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
 type SpecialCharacter = ' ' | '`' | '~' | '!' | '@' | '#' | '$' | '%' | '^' | '&' | '*' | '(' | ')' | '-' | '_' | '+' | '=' | '[' | '{' | '}' | ']' | '\\' | '|' | ';' | ':' | '"' | '\'' | ',' | '<' | '>' | '.' | '?' | '/';
 
-type KeyCharacter = AlphaCharacter | NumericCharacter | SpecialCharacter;
+type KeyCharacter = LowerCaseCharacter | NumericCharacter | SpecialCharacter;
 
 type IKeyBind<TKey extends KeyCharacter = KeyCharacter> = {
   readonly altKey?: boolean;
@@ -19,7 +18,7 @@ type IKeyBind<TKey extends KeyCharacter = KeyCharacter> = {
 
 const modifiers = ['ctrlKey', 'altKey', 'shiftKey', 'metaKey'] as const satisfies readonly (keyof IKeyBind)[];
 
-type KeyBindString = `${'ctrl+'|''}${'alt+'|''}${'shift+'|''}${'meta+'|''}${KeyCharacter}`;
+export type KeyBindString = `${'ctrl+'|''}${'alt+'|''}${'shift+'|''}${'meta+'|''}${KeyCharacter}`;
 
 type UnSuffixKey<T extends `${string}Key`> = T extends `${infer K}Key` ? K : never;
 
@@ -53,6 +52,7 @@ export class KeyBindService {
     }
 
     const bindStr = this.makeBindStr(e as IKeyBind);
+    console.debug('keyEventCalled', bindStr);
 
     const callback = this.#registry.get(bindStr);
     try {
@@ -88,6 +88,6 @@ export class KeyBindService {
       .map(mod => mod.slice(0, -3) as UnSuffixKey<typeof mod>)
       .map(modPrefix => `${modPrefix}+` as const);
 
-    return (mods.join('') + e.key) as KeyBindString;
+    return (mods.join('') + e.key.toLowerCase()) as KeyBindString;
   }
 }

--- a/src/app/shared/services/key-bind.service.ts
+++ b/src/app/shared/services/key-bind.service.ts
@@ -42,8 +42,7 @@ export class KeyBindService {
       case Platform.Linux:
       case Platform.Windows:
       default:
-        this.icons = { symbolic: true, ctrlKey: '⌃', altKey: '⌥', shiftKey: '⇧', metaKey: '⊞' };
-        // this.icons = { symbolic: false, ctrlKey: 'Ctrl', altKey: 'Alt', shiftKey: 'Shift', metaKey: '⊞' };
+        this.icons = { symbolic: false, ctrlKey: 'Ctrl', altKey: 'Alt', shiftKey: 'Shift', metaKey: '⊞' };
         break;
     }
   }

--- a/src/app/shared/services/materials/contour-material.service.ts
+++ b/src/app/shared/services/materials/contour-material.service.ts
@@ -1,46 +1,12 @@
 import { inject, Injectable } from '@angular/core';
 import { BaseMaterialService } from './base-material.service';
 import { Color, Material, MeshNormalMaterial, ShaderMaterial } from 'three';
-import { xyzPositionVertexShader } from '../../shaders/xyzPosition.vertex-shader';
+import xyzPositionVertexShader from '../../shaders/xyzPosition.vertex-shader.glsl';
 import { SettingsService } from '../settings/settings.service';
 import { colorToVector3 } from '../../functions/color-to-vector3';
 import { LocalizeService } from '../localize.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-
-/**
- * Fragment shader that uses `xyzPosition` to
- * set fragment color to `contourColor` if the fragment is on
- * a multiple of `yIncrement`, or sub-increment.
- *
- * Sub-increments are 30% closer to black and are 1/3 the thickness of increments.
- *
- */
-const fragmentShader = `
-uniform float yIncrement;
-uniform vec3 contourColor;
-uniform float roundPrecision;
-uniform uint numSubIncrements;
-
-varying vec3 xyzPosition;
-
-void main()
-{
-  // primary increment
-  if (mod( xyzPosition.y, yIncrement ) < roundPrecision) {
-    gl_FragColor.rgb = contourColor;
-    gl_FragColor.a = 1.0;
-  }
-  else {
-    // sub-increments
-    for (uint i = 0u; i < numSubIncrements; ++i) {
-      if (mod( xyzPosition.y + yIncrement * float(i) / float(numSubIncrements) , yIncrement ) < roundPrecision / 3.0) {
-        gl_FragColor.rgb = mix(contourColor, vec3(0,0,0), 0.3);
-        gl_FragColor.a = 1.0;
-      }
-    }
-  }
-}
-`;
+import fragmentShader from '../../shaders/contour-material.fragment-shader.glsl';
 
 @Injectable()
 export class ContourMaterialService extends BaseMaterialService<Material[]> {

--- a/src/app/shared/services/materials/elevation-material.service.ts
+++ b/src/app/shared/services/materials/elevation-material.service.ts
@@ -2,36 +2,8 @@ import { Injectable } from '@angular/core';
 import { BaseMaterialService } from './base-material.service';
 import { Color, ShaderMaterial } from 'three';
 import { colorToVector3 } from '../../functions/color-to-vector3';
-import { xyzPositionVertexShader } from '../../shaders/xyzPosition.vertex-shader';
-
-/**
- * Fragment shader that uses `xyzPosition` to set
- * fragment color between `colorMin` and `colorMax` based
- * on the Y coordinate's distance between `yMin` and `yMax`.
- *
- * Depends on {@link xyzPositionVertexShader}.
- */
-const fragmentShader = `
-uniform float yMin;
-uniform float yMax;
-
-uniform vec3 colorMin;
-uniform vec3 colorMax;
-
-varying vec3 xyzPosition;
-
-void main()
-{
-  float yPos = xyzPosition.y;
-
-  yPos = clamp(yPos, yMin, yMax);
-  float fractionBetweenMinAndMax = (yPos - yMin) / (yMax - yMin);
-
-  gl_FragColor.rgb = mix(colorMin, colorMax, fractionBetweenMinAndMax);
-  gl_FragColor.a = 1.0;
-}
-`;
-
+import xyzPositionVertexShader from '../../shaders/xyzPosition.vertex-shader.glsl';
+import elevationFragmentShader from '../../shaders/elevation.fragment-shader.glsl';
 
 @Injectable()
 export class ElevationMaterialService extends BaseMaterialService<ShaderMaterial> {
@@ -49,7 +21,7 @@ export class ElevationMaterialService extends BaseMaterialService<ShaderMaterial
       colorMin: { value: colorToVector3(new Color(this.defaultColorMin)) },
       colorMax: { value: colorToVector3(new Color(this.defaultColorMax)) },
     },
-    fragmentShader,
+    fragmentShader: elevationFragmentShader,
     vertexShader: xyzPositionVertexShader,
   });
   override readonly type = 'elevation';

--- a/src/app/shared/services/platform.service.ts
+++ b/src/app/shared/services/platform.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@angular/core';
+
+declare global {
+  interface NavigatorUAData {
+    readonly brands: readonly { brand: string, version: string }[];
+    readonly mobile: boolean;
+    readonly platform: string;
+  }
+
+  interface Navigator {
+    readonly userAgentData?: NavigatorUAData;
+  }
+}
+
+export enum Platform {
+  Windows = 1,
+  MacOS = 2,
+  iDevice = 3,
+  Android = 4,
+  Linux = 5,
+  Other = 100,
+}
+
+@Injectable()
+export class PlatformService {
+
+  readonly platform =
+    PlatformService.getPlatformFromUserAgentDataPlatform(window.navigator.userAgentData?.platform)
+    ?? PlatformService.getPlatformFromNavigatorPlatform(window.navigator.platform)
+    ?? Platform.Other;
+
+
+  static getPlatformFromNavigatorPlatform(platform?: string | null) {
+    if (!platform) {
+      return undefined;
+    }
+    if (platform.startsWith('iP')) {
+      return Platform.iDevice;
+    }
+
+    platform = platform.toLowerCase();
+
+    if (platform === 'win32') {
+      return Platform.Windows;
+    }
+    if (platform.startsWith('linux')) {
+      return Platform.Linux;
+    }
+    if (platform.startsWith('mac')) {
+      return Platform.MacOS;
+    }
+
+    return undefined;
+  }
+
+  static getPlatformFromUserAgentDataPlatform(userAgentDataPlatform?: string) {
+    if (!userAgentDataPlatform) {
+      return undefined;
+    }
+
+    userAgentDataPlatform = userAgentDataPlatform.toLowerCase();
+
+    if (userAgentDataPlatform.includes('macos')) {
+      return Platform.MacOS;
+    }
+    if (userAgentDataPlatform.includes('windows')) {
+      return Platform.Windows;
+    }
+    if (userAgentDataPlatform.includes('android')) {
+      return Platform.Android;
+    }
+
+    return undefined;
+  }
+}

--- a/src/app/shared/services/platform.service.ts
+++ b/src/app/shared/services/platform.service.ts
@@ -60,14 +60,17 @@ export class PlatformService {
 
     userAgentDataPlatform = userAgentDataPlatform.toLowerCase();
 
-    if (userAgentDataPlatform.includes('macos')) {
+    if (userAgentDataPlatform.startsWith('macos')) {
       return Platform.MacOS;
     }
-    if (userAgentDataPlatform.includes('windows')) {
+    if (userAgentDataPlatform.startsWith('windows')) {
       return Platform.Windows;
     }
-    if (userAgentDataPlatform.includes('android')) {
+    if (userAgentDataPlatform.startsWith('android')) {
       return Platform.Android;
+    }
+    if (userAgentDataPlatform.startsWith('linux')) {
+      return Platform.Linux;
     }
 
     return undefined;

--- a/src/app/shared/shaders/contour-material.fragment-shader.glsl
+++ b/src/app/shared/shaders/contour-material.fragment-shader.glsl
@@ -1,0 +1,33 @@
+/**
+ * Fragment shader that uses `xyzPosition` to
+ * set fragment color to `contourColor` if the fragment is on
+ * a multiple of `yIncrement`, or sub-increment.
+ *
+ * Sub-increments are 30% closer to black and are 1/3 the thickness of increments.
+ *
+ */
+
+uniform float yIncrement;
+uniform vec3 contourColor;
+uniform float roundPrecision;
+uniform uint numSubIncrements;
+
+varying vec3 xyzPosition;
+
+void main()
+{
+    // primary increment
+    if (mod( xyzPosition.y, yIncrement ) < roundPrecision) {
+        gl_FragColor.rgb = contourColor;
+        gl_FragColor.a = 1.0;
+    }
+    else {
+        // sub-increments
+        for (uint i = 0u; i < numSubIncrements; ++i) {
+            if (mod( xyzPosition.y + yIncrement * float(i) / float(numSubIncrements) , yIncrement ) < roundPrecision / 3.0) {
+                gl_FragColor.rgb = mix(contourColor, vec3(0,0,0), 0.3);
+                gl_FragColor.a = 1.0;
+            }
+        }
+    }
+}

--- a/src/app/shared/shaders/elevation.fragment-shader.glsl
+++ b/src/app/shared/shaders/elevation.fragment-shader.glsl
@@ -1,0 +1,26 @@
+/**
+ * Fragment shader that uses `xyzPosition` to set
+ * fragment color between `colorMin` and `colorMax` based
+ * on the Y coordinate's distance between `yMin` and `yMax`.
+ *
+ * Depends on {@link xyzPositionVertexShader}.
+ */
+
+uniform float yMin;
+uniform float yMax;
+
+uniform vec3 colorMin;
+uniform vec3 colorMax;
+
+varying vec3 xyzPosition;
+
+void main()
+{
+    float yPos = xyzPosition.y;
+
+    yPos = clamp(yPos, yMin, yMax);
+    float fractionBetweenMinAndMax = (yPos - yMin) / (yMax - yMin);
+
+    gl_FragColor.rgb = mix(colorMin, colorMax, fractionBetweenMinAndMax);
+    gl_FragColor.a = 1.0;
+}

--- a/src/app/shared/shaders/xyzPosition.vertex-shader.glsl
+++ b/src/app/shared/shaders/xyzPosition.vertex-shader.glsl
@@ -1,7 +1,6 @@
 /**
- * Vertex shader that sets `xyzPosition`
+ * Vertex shader that sets `xyzPosition`.
  */
-export const xyzPositionVertexShader = `
 varying vec3 xyzPosition;
 
 void main() {
@@ -9,4 +8,4 @@ void main() {
 
     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
 }
-`;
+

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,4 @@
+declare module "*.glsl" {
+  const content: string;
+  export default content;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,8 +23,11 @@
     "lib": [
       "ES2022",
       "dom"
-    ]
+    ],
   },
+  "include": [
+    "src/types.d.ts"
+  ],
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,


### PR DESCRIPTION
Version 0.3.13

Core changes:
* keybindings
   -  KeyBindService
      * global key events are passed in with `keyEventCalled()` (currently called by app.component)
      * `register$()` and `registerStr$()` can be used to observably register to receive callbacks for keybindings, which can only be registered once at a time
      * provides platform localization of keybindings
   - `mapperKeyBind` and `mapper-key-bind-icon`
      * `mapperKeyBind` directive can be applied to any element with a `(click)` output, which will be called when the keybind is triggered
      * `mapper-key-bind-icon` can live within an element with `mapperKeyBind` directive and renders the symbols of that keybind.
      ![image](https://github.com/skgrush/cavern-seer-mapper/assets/21208885/02919d95-9107-4076-937e-67acb3ff7be6)
      ![image](https://github.com/skgrush/cavern-seer-mapper/assets/21208885/8b9e7f48-87e5-45f6-8e23-6a5e7c72e431)
* PlatformService
   - provides minimal abstraction to detect the user's platform

Additional changes:
* GLSL shaders now live in `.glsl` files, and now use Angular/Vite loaders to load GLSL files as string constants
* 