### PR TITLE
Full height mapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavern-seer-mapper",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "homepage": "https://github.com/skgrush/cavern-seer-mapper#readme",
   "license": "MIT",
   "author": {

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -1,38 +1,38 @@
-import { Injectable, inject } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
-  BehaviorSubject,
-  Observable,
-  Subject,
   animationFrames,
+  BehaviorSubject,
+  combineLatest,
   defer,
   distinctUntilChanged,
   filter,
   fromEvent,
   map,
+  Observable,
+  of,
   scan,
+  startWith,
+  Subject,
   switchMap,
   takeUntil,
   tap,
-  combineLatest,
-  of,
-  startWith,
 } from 'rxjs';
 import {
   AmbientLight,
   Box3,
   Camera,
   Clock,
+  DirectionalLight,
   GridHelper,
+  Intersection,
   OrthographicCamera,
   Raycaster,
-  SRGBColorSpace,
   Scene,
+  SRGBColorSpace,
   Vector2,
   Vector3,
   WebGLRenderer,
-  DirectionalLight,
-  Intersection,
 } from 'three';
 import { markSceneOfItemForReRender } from '../functions/mark-scene-of-item-for-rerender';
 import { traverseSome } from '../functions/traverse-some';
@@ -44,7 +44,7 @@ import { IMapperUserData } from '../models/user-data';
 import { ignoreNullish } from '../operators/ignore-nullish';
 import { LocalizeService } from './localize.service';
 import { ModelManagerService } from './model-manager.service';
-import { SettingsService } from "./settings/settings.service";
+import { SettingsService } from './settings/settings.service';
 import { SVGRenderer } from 'three/examples/jsm/renderers/SVGRenderer.js';
 import { TemporaryAnnotation } from '../models/annotations/temporary.annotation';
 import { MaterialManagerService } from './materials/material-manager.service';

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -32,6 +32,7 @@ import {
   Vector3,
   WebGLRenderer,
   DirectionalLight,
+  Intersection,
 } from 'three';
 import { markSceneOfItemForReRender } from '../functions/mark-scene-of-item-for-rerender';
 import { traverseSome } from '../functions/traverse-some';
@@ -403,13 +404,17 @@ export class CanvasService {
   raycastFromCamera(coords: Vector2) {
     this.#raycaster.setFromCamera(coords, this.#orthoControls!.camera);
 
-    return this.#raycaster.intersectObjects(this.#scene.children, true);
+    return this.#raycaster.intersectObject(this.#scene);
   }
 
   raycast(origin: Vector3, direction: Vector3) {
     this.#raycaster.set(origin, direction);
 
-    return this.#raycaster.intersectObjects(this.#scene.children, true);
+    return this.#raycaster.intersectObject(this.#scene);
+  }
+
+  raycastWithPreparedRaycaster(raycaster: Raycaster, recursive?: boolean, optionalTarget?: Intersection[]) {
+    return raycaster.intersectObject(this.#scene, recursive, optionalTarget);
   }
 
   enableControls(enable: boolean) {

--- a/src/app/shared/services/tools/full-height-map-tool.service.ts
+++ b/src/app/shared/services/tools/full-height-map-tool.service.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject, map, of, switchMap, take, tap, timer } from 'rxjs';
 import { ModelManagerService } from '../model-manager.service';
 import { ignoreNullish } from '../../operators/ignore-nullish';
 import { TemporaryAnnotation } from '../../models/annotations/temporary.annotation';
-import { BoxGeometry, Group, Intersection, Mesh, MeshBasicMaterial, Object3D, Raycaster, Vector3 } from 'three';
+import { BoxGeometry, Group, Intersection, Mesh, MeshBasicMaterial, Raycaster, Vector3 } from 'three';
 import { CanvasService } from '../canvas.service';
 import { IMapperUserData } from '../../models/user-data';
 import { LocalizeService } from '../localize.service';

--- a/src/app/shared/services/tools/full-height-map-tool.service.ts
+++ b/src/app/shared/services/tools/full-height-map-tool.service.ts
@@ -16,7 +16,7 @@ import { AlertService, AlertType } from '../alert.service';
 
 const yUp = new Vector3(0, 1, 0);
 const yDown = new Vector3(0, -1, 0);
-const fontSize = 0.05;
+// const fontSize = 0.05;
 
 type IntersectionPair = {
   readonly floor: Intersection;
@@ -24,7 +24,9 @@ type IntersectionPair = {
 }
 
 class MapProbe {
-  readonly identifier = `${this.origin.x}, ${this.origin.y}, ${this.origin.z}`;
+  get identifier() {
+    return `${this.origin.x}, ${this.origin.y}, ${this.origin.z}`;
+  }
 
   readonly group: Group;
 
@@ -33,6 +35,7 @@ class MapProbe {
     readonly downIntersections: readonly Intersection[],
     readonly upIntersections: readonly Intersection[],
     readonly minY: number,
+    readonly fontSize: number,
     localize: LocalizeService,
   ) {
     this.group = this.#toGroup(localize);
@@ -52,7 +55,8 @@ class MapProbe {
 
     const highestPoint = [...this.upIntersections, ...this.downIntersections]
       .map(i => i.point)
-      .sort((a, b) => b.y - a.y)[0];
+      .sort((a, b) => b.y - a.y)
+      [0];
 
     return pairs
       .map(({ floor, ceiling }) => ceiling.point.y - floor.point.y)
@@ -60,21 +64,21 @@ class MapProbe {
       // we want heights ordered from top to bottom
       .reverse()
       .map((txt, i) => {
-        const textGroup = this.#builSingleTextItem(txt);
+        const textGroup = this.#buildSingleTextItem(txt);
         textGroup.position.y = highestPoint.y - this.origin.y;
-        textGroup.position.z = fontSize * i;
+        textGroup.position.z = this.fontSize * i;
         return textGroup;
       });
   }
 
-  #builSingleTextItem(text: string) {
+  #buildSingleTextItem(text: string) {
 
     const textGeometry = new TextGeometry(
       text,
       {
         font: droidSansFont,
-        size: fontSize,
-        height: fontSize / 5,
+        size: this.fontSize,
+        height: this.fontSize / 5,
       },
     );
     textGeometry.computeBoundingBox();
@@ -182,6 +186,7 @@ export class FullHeightMapToolService extends BaseClickToolService {
     raycaster.params['Mesh'].threshold = 0.1;
 
     const stepSize = this.#stepSize;
+    const fontSize = stepSize / 5;
     const tmpResults: Intersection[] = [];
     const finalResults: MapProbe[] = [];
 
@@ -219,7 +224,7 @@ export class FullHeightMapToolService extends BaseClickToolService {
           continue;
         }
 
-        finalResults.push(new MapProbe(origin, downResults, upResults, minY, this.#localize));
+        finalResults.push(new MapProbe(origin, downResults, upResults, minY, fontSize, this.#localize));
       }
     }
 

--- a/src/app/shared/services/tools/full-height-map-tool.service.ts
+++ b/src/app/shared/services/tools/full-height-map-tool.service.ts
@@ -1,0 +1,237 @@
+import { inject, Injectable } from '@angular/core';
+import { BaseClickToolService } from './base-tool.service';
+import { BehaviorSubject, map, of, switchMap, take, tap, timer } from 'rxjs';
+import { ModelManagerService } from '../model-manager.service';
+import { ignoreNullish } from '../../operators/ignore-nullish';
+import { TemporaryAnnotation } from '../../models/annotations/temporary.annotation';
+import { Group, Intersection, Mesh, MeshBasicMaterial, Object3D, Raycaster, Vector3 } from 'three';
+import { CanvasService } from '../canvas.service';
+import { IMapperUserData } from '../../models/user-data';
+import { LocalizeService } from '../localize.service';
+import { TextGeometry } from 'three/examples/jsm/geometries/TextGeometry.js';
+import { droidSansFont } from '../../models/annotations/font';
+import { RenderingOrder } from '../../models/rendering-layers';
+import { GroupRenderModel } from '../../models/render/group.render-model';
+import { AlertService, AlertType } from '../alert.service';
+
+const yUp = new Vector3(0, 1, 0);
+const yDown = new Vector3(0, -1, 0);
+const fontSize = 0.05;
+
+type IntersectionPair = {
+  readonly floor: Intersection;
+  readonly ceiling: Intersection;
+}
+
+class MapProbe {
+  readonly identifier = `${this.origin.x}, ${this.origin.y}, ${this.origin.z}`;
+
+  readonly group: Group;
+
+  constructor(
+    readonly origin: Vector3,
+    readonly downIntersections: readonly Intersection[],
+    readonly upIntersections: readonly Intersection[],
+    readonly minY: number,
+    localize: LocalizeService,
+  ) {
+    this.group = this.#toGroup(localize);
+  }
+
+  #toGroup(localize: LocalizeService) {
+    const pairs = [...this.#getPairs()];
+
+    const group = new Group();
+    group.add(...this.#buildText(localize, pairs));
+    group.position.copy(this.origin);
+
+    return group;
+  }
+
+  #buildText(localize: LocalizeService, pairs: IntersectionPair[]) {
+
+    const highestPoint = [...this.upIntersections, ...this.downIntersections]
+      .map(i => i.point)
+      .sort((a, b) => b.y - a.y)[0];
+
+    return pairs
+      .map(({ floor, ceiling }) => ceiling.point.y - floor.point.y)
+      .map(len => localize.formatLength(len, 0, 1))
+      // we want heights ordered from top to bottom
+      .reverse()
+      .map((txt, i) => {
+        const textMesh = this.#builSingleTextItem(txt);
+        textMesh.position.y = highestPoint.y - this.origin.y;
+        textMesh.position.z = fontSize * i;
+        return textMesh;
+      });
+  }
+
+  #builSingleTextItem(text: string) {
+
+    const textGeometry = new TextGeometry(
+      text,
+      {
+        font: droidSansFont,
+        size: fontSize,
+        height: fontSize / 5,
+        // bevelEnabled: true,
+        // bevelSize: fontSize,
+      },
+    );
+    const textMat = new MeshBasicMaterial({ color: 0x00 });
+    textMat.depthTest = false;
+
+    const mesh = new Mesh(
+      textGeometry,
+      textMat,
+    );
+    mesh.rotation.set(-Math.PI / 2, 0, 0);
+    mesh.renderOrder = RenderingOrder.Annotation;
+    return mesh;
+  }
+
+  *#getPairs(): Generator<IntersectionPair> {
+    const bottom = this.downIntersections[this.downIntersections.length - 1];
+
+    let nextFloor: undefined | Intersection = bottom;
+    while (nextFloor) {
+      const nextCeiling = this.#getFirstUpAbove(nextFloor.point);
+      if (!nextCeiling) {
+        return;
+      }
+      yield { floor: nextFloor, ceiling: nextCeiling };
+
+      nextFloor = this.#getFirstDownAbove(nextCeiling.point);
+    }
+  }
+
+  #getFirstDownAbove(point: Vector3) {
+    return this.downIntersections.findLast(i => i.point.y > point.y);
+  }
+  #getFirstUpAbove(point: Vector3) {
+    return this.upIntersections.find(i => i.point.y > point.y);
+  }
+}
+
+@Injectable()
+export class FullHeightMapToolService extends BaseClickToolService {
+
+  readonly #modelManager = inject(ModelManagerService);
+  readonly #canvas = inject(CanvasService);
+  readonly #localize = inject(LocalizeService);
+  readonly #alert = inject(AlertService);
+
+  readonly #ceilingHeightsGroup$ = new BehaviorSubject<undefined | TemporaryAnnotation<Group>>(undefined);
+
+  #stepSize = 0.25;
+
+  override readonly id = 'full-height-map';
+  override readonly label = 'Fully map ceiling heights';
+  override readonly icon$ = this.#ceilingHeightsGroup$.pipe(
+    map(annos => ({
+      icon: annos ? 'delete_forever' : 'map',
+    })),
+  );
+
+  override click() {
+    this.#modelManager.currentOpenGroup$.pipe(
+      take(1),
+      ignoreNullish(),
+      switchMap(group => {
+        if (this.#ceilingHeightsGroup$.value !== undefined) {
+          this.#clearAnnotations(group);
+          return of();
+        }
+
+        this.#alert.alert(AlertType.warning, 'Generating full height-map will take time...');
+
+        return timer(0).pipe(
+          tap(() => this.#generateAnnotations(group)),
+        );
+      })
+    ).subscribe();
+  }
+
+  #generateAnnotations(group: GroupRenderModel) {
+    const boundingBox = group.getBoundingBox();
+
+    const { x: minX, z: minZ, y: minY } = boundingBox.min;
+    const { x: maxX, z: maxZ, y: maxY } = boundingBox.max;
+    const rangeY = maxY - minY;
+
+    const raycaster = new Raycaster(new Vector3(), yDown, 0, rangeY);
+
+    const stepSize = this.#stepSize;
+    const tmpResults: Intersection[] = [];
+    const finalResults: MapProbe[] = [];
+
+    function isSerializedModelIntersection(int: Intersection) {
+      return (int.object.userData as IMapperUserData).fromSerializedModel;
+    }
+
+    const ts0 = performance.now();
+
+    for (let x = minX; x <= maxX; x += stepSize) {
+      for (let z = minZ; z <= maxZ; z += stepSize) {
+        const origin = new Vector3(x, maxY, z);
+        raycaster.ray.direction = yDown;
+        raycaster.ray.origin.copy(origin);
+
+        tmpResults.length = 0;
+        this.#canvas.raycastWithPreparedRaycaster(raycaster, true, tmpResults);
+
+        const downResults = tmpResults.filter(isSerializedModelIntersection);
+
+        if (!downResults.length) {
+          continue;
+        }
+        const lastDownResult = downResults[downResults.length - 1];
+
+        raycaster.ray.direction = yUp;
+        raycaster.ray.origin.copy(lastDownResult.point);
+
+        tmpResults.length = 0;
+        this.#canvas.raycastWithPreparedRaycaster(raycaster, true, tmpResults);
+
+        const upResults = tmpResults.filter(isSerializedModelIntersection);
+
+        if (!upResults.length) {
+          continue;
+        }
+
+        finalResults.push(new MapProbe(origin, downResults, upResults, minY, this.#localize));
+      }
+    }
+
+    const ts1 = performance.now();
+
+    const annotationGroup = new Group();
+    annotationGroup.children.push(...finalResults.map(r => r.group));
+    const anno = new TemporaryAnnotation(
+      'full-height-map',
+      annotationGroup,
+      o => o.position,
+    );
+
+    group.addAnnotation(anno);
+
+    this.#ceilingHeightsGroup$.next(anno);
+
+    this.#alert.alert(AlertType.info, `Generated full height-map in ${Math.round(ts1 - ts0) / 1e3} sec`, 'X', {
+      duration: 10e3,
+    })
+  }
+
+  #clearAnnotations(group: GroupRenderModel) {
+    const anno = this.#ceilingHeightsGroup$.value;
+    if (!anno) {
+      return;
+    }
+    group.removeAnnotations(new Set([anno]));
+
+    this.#ceilingHeightsGroup$.next(undefined);
+  }
+
+
+}

--- a/src/app/shared/services/tools/index.ts
+++ b/src/app/shared/services/tools/index.ts
@@ -7,6 +7,7 @@ import { CrossSectionToolService } from "./cross-section-tool.service";
 import { ToggleMaterialSidesToolService } from "./toggle-material-sides-tool.service";
 import {ToggleGridToolService} from "./toggle-grid-tool.service";
 import { ToggleEmbeddedAnnotationsToolService } from './toggle-embedded-annotations-tool.service';
+import { FullHeightMapToolService } from './full-height-map-tool.service';
 
 export function toolsProviders() {
   return makeEnvironmentProviders([
@@ -17,6 +18,7 @@ export function toolsProviders() {
     ToggleMaterialSidesToolService,
     ToggleGridToolService,
     ToggleEmbeddedAnnotationsToolService,
+    FullHeightMapToolService,
     { provide: EXCLUSIVE_TOOL_SERVICES, useExisting: NoToolService, multi: true },
     { provide: EXCLUSIVE_TOOL_SERVICES, useExisting: DistanceMeasureToolService, multi: true },
     { provide: EXCLUSIVE_TOOL_SERVICES, useExisting: CeilingHeightToolService, multi: true },
@@ -24,5 +26,6 @@ export function toolsProviders() {
     { provide: NONEXCLUSIVE_TOOL_SERVICES, useExisting: ToggleMaterialSidesToolService, multi: true },
     { provide: NONEXCLUSIVE_TOOL_SERVICES, useExisting: ToggleGridToolService, multi: true },
     { provide: NONEXCLUSIVE_TOOL_SERVICES, useExisting: ToggleEmbeddedAnnotationsToolService, multi: true },
+    { provide: NONEXCLUSIVE_TOOL_SERVICES, useExisting: FullHeightMapToolService, multi: true },
   ]);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "useDefineForClassFields": false,
     "lib": [
       "ES2022",
+      "ES2023.Array",
       "dom"
     ],
   },


### PR DESCRIPTION
Version 0.3.14

Core changes:
* FullHeightMapToolService (closes #54)
   - service iterates across map and creates height map with MapProbes
   - MapProbe class encapsulates all logic of converting a vertical set of intersections into annotation

This is definitely still a work in progress...

<img width="530" alt="image" src="https://github.com/skgrush/cavern-seer-mapper/assets/21208885/f0e8ff53-34c9-4288-9c4b-2c7b1909c77a">
