### PR TITLE
Exclude embeds from model exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavern-seer-mapper",
-      "version": "0.3.14",
+      "version": "0.3.15",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavern-seer-mapper",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "homepage": "https://github.com/skgrush/cavern-seer-mapper#readme",
   "license": "MIT",
   "author": {

--- a/src/app/shared/functions/temporarily-set.ts
+++ b/src/app/shared/functions/temporarily-set.ts
@@ -1,0 +1,16 @@
+import { BehaviorSubject, Observable } from 'rxjs';
+
+/**
+ * When observed, set the subject to the given value.
+ * When unsubscribed, set the subject back to its original value.
+ */
+export function temporarilySet$<T>(subject: BehaviorSubject<T>, to: T) {
+  return new Observable<void>(() => {
+    const originalValue = subject.value;
+    if (originalValue !== to) {
+      subject.next(to);
+      return () => subject.next(originalValue);
+    }
+    return () => undefined;
+  });
+}

--- a/src/app/shared/services/canvas.service.ts
+++ b/src/app/shared/services/canvas.service.ts
@@ -49,6 +49,7 @@ import { SVGRenderer } from 'three/examples/jsm/renderers/SVGRenderer.js';
 import { TemporaryAnnotation } from '../models/annotations/temporary.annotation';
 import { MaterialManagerService } from './materials/material-manager.service';
 import { ElevationMaterialService } from './materials/elevation-material.service';
+import { temporarilySet$ } from '../functions/temporarily-set';
 
 @Injectable()
 export class CanvasService {
@@ -264,6 +265,10 @@ export class CanvasService {
     this.#embeddedAnnotationsVisibleSubject.next(
       !this.#embeddedAnnotationsVisibleSubject.value,
     );
+  }
+
+  temporarilySetEmbeddedAnnotations$(to: boolean) {
+    return temporarilySet$(this.#embeddedAnnotationsVisibleSubject, to);
   }
 
   /**

--- a/src/app/shared/services/tools/toggle-embedded-annotations-tool.service.ts
+++ b/src/app/shared/services/tools/toggle-embedded-annotations-tool.service.ts
@@ -9,7 +9,7 @@ export class ToggleEmbeddedAnnotationsToolService extends BaseClickToolService {
 
   override readonly id = 'toggle-embedded-annotations';
   override readonly label = 'Toggle embedded annotations';
-  override readonly icon$ = this.#canvasService.gridVisible$.pipe(
+  override readonly icon$ = this.#canvasService.embeddedAnnotationsVisible$.pipe(
     map(visible => ({
       icon: 'sticky_note_2',
       fontSet: visible ? 'material-icons' : 'material-icons-outlined',


### PR DESCRIPTION
Version 0.3.15

Core changes:
* When exporting, triggers hiding embedded-annotations
* During export, if any objects are marked invisible, a clone is made and those objects are removed
   - this is also an enhancement for past exporting where invisible objects were still ending up in the model, as exporters don't account for the `visible` flag

Bug fixes:
* The icon for toggle-embedded-annotations was visually toggling based on grid visibility incorrectly!